### PR TITLE
Add HTTP API wrapper and refactor MCP server into modular API layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The finmap.org MCP server provides comprehensive historical data from the US, UK
 | American Stock Exchange | `amex` | United States | 2024-12-09 | Daily |
 | US Combined (AMEX + NASDAQ + NYSE) | `us-all` | United States | 2024-12-09 | Daily |
 | London Stock Exchange | `lse` | United Kingdom | 2025-02-07 | Hourly (weekdays) |
-| Hong Kong Stock Exchange | `hkex` | Hong Kong | 2025-09-26 | Every 30 minutes (weekdays) |
+| Hong Kong Stock Exchange | `hkex` | Hong Kong | 2025-09-29 | Every 30 minutes (weekdays) |
 | Borsa Istanbul | `bist` | Turkey | 2015-11-30 | Every two months |
 | Moscow Exchange | `moex` | Russia | 2011-12-19 | Every 15 minutes (weekdays) |
 
@@ -59,13 +59,31 @@ npx finmap-mcp
 }
 ```
 
+
+## HTTP API Wrapper
+
+The server also exposes a compact HTTP API for GPT Actions and direct integration.
+
+- `GET /api/openapi.json`
+- `GET /api/list-exchanges`
+- `POST /api/list-sectors`
+- `POST /api/list-sector-companies`
+- `POST /api/search-companies`
+- `POST /api/market-overview`
+- `POST /api/sector-performance`
+- `POST /api/rank-stocks`
+- `POST /api/stock-snapshot`
+- `POST /api/company-profile`
+
+A ready-to-import GPT Actions schema is available in `gpt-actions.yaml`.
+
 ## Available Tools
 
-### 1. `list_exchanges`
-  - Title: List exchanges
-  - Description: Return supported exchanges with IDs, names, country, currency, earliest available date, and update frequency.
+### 1. `list_supported_exchanges`
+  - Title: List supported stock exchanges
+  - Description: Return metadata for all supported stock exchanges in the Finmap dataset. Includes exchange ID, exchange name, country, currency, earliest available historical data date, and update frequency.
 
-  **Example Promt:** `#finmap-mcp list available stock exchanges`
+  **Example Prompt:** `#finmap-mcp list available stock exchanges`
 
   **Example Response:**
   ```json
@@ -132,18 +150,18 @@ npx finmap-mcp
         "name": "Hong Kong Stock Exchange",
         "country": "Hong Kong",
         "currency": "HKD",
-        "availableSince": "2025-09-26",
+        "availableSince": "2025-09-29",
         "updateFrequency": "Every 30 minutes (weekdays)"
       }
     ]
   }
   ```
 
-### 2. `list_sectors`
-  - Title: List sectors
-  - Description: List available business sectors for an exchange on a specific date, including item counts.
+### 2. `list_exchange_sectors`
+  - Title: List sectors for a stock exchange
+  - Description: Return all business sectors available on a specific exchange and trading date. Each sector includes the number of companies in that sector.
 
-  **Example Promt:** `#finmap-mcp List sectors for the Turkish stock exchange`
+  **Example Prompt:** `#finmap-mcp List sectors for the Turkish stock exchange`
   
   **Example Response:**
   ```json
@@ -236,11 +254,11 @@ npx finmap-mcp
   }
   ```
 
-### 3. `list_tickers`
-  - Title: List tickers by sector
-  - Description: Return company tickers and names for an exchange on a specific date, grouped by sector.
+### 3. `list_sector_companies`
+  - Title: List companies by sector
+  - Description: Return company tickers and names grouped by sector for an exchange on a specific trading date. Optionally filter results by a single sector.
 
-  **Example Promt:** `#finmap-mcp List companies in the Real Estate sector`
+  **Example Prompt:** `#finmap-mcp List companies in the Real Estate sector`
   
   **Example Response:**
   ```json
@@ -271,11 +289,11 @@ npx finmap-mcp
   }
   ```
 
-### 4. `search_companies`
-  - Title: Search companies
-  - Description: Find companies by partial name or ticker on an exchange and return best matches.
+### 4. `search_exchange_companies`
+  - Title: Search companies by name or ticker
+  - Description: Search for companies on a specific exchange by partial ticker symbol or company name. Results are ranked by relevance using ticker and name similarity.
 
-  **Example Promt:** `#finmap-mcp Search for companies named 'Sprouts'`
+  **Example Prompt:** `#finmap-mcp Search for companies named 'Sprouts'`
 
   **Example Response:**
   ```json
@@ -295,11 +313,11 @@ npx finmap-mcp
   }
   ```
 
-### 5. `get_market_overview`
-  - Title: Market overview
-  - Description: Get total market cap, volume, value, and performance for an exchange on a specific date with a sector breakdown.
+### 5. `analyze_market_overview`
+  - Title: Analyze market overview
+  - Description: Return aggregated statistics for a stock exchange on a specific date. Includes total market capitalization, trading volume, total traded value, number of trades, and sector-level market breakdown.
 
-  **Example Promt:** `#finmap-mcp market overview for Nasdaq`
+  **Example Prompt:** `#finmap-mcp market overview for Nasdaq`
   
   **Example Response:**
   ```json
@@ -358,11 +376,11 @@ npx finmap-mcp
   }
   ```
 
-### 6. `get_sectors_overview`
-  - Title: Sector performance
-  - Description: Get aggregated performance metrics by sector for an exchange on a specific date.
+### 6. `analyze_sector_performance`
+  - Title: Analyze sector performance
+  - Description: Return aggregated metrics for each sector in a stock exchange. Includes sector market capitalization, price change percentage, trading volume, traded value, number of trades, and number of companies in the sector.
 
-  **Example Promt:** `#finmap-mcp Get overview for the Utilities sector`
+  **Example Prompt:** `#finmap-mcp Get overview for the Utilities sector`
   
   **Example Response:**
   ```json
@@ -384,11 +402,11 @@ npx finmap-mcp
   }
   ```
 
-### 7. `get_stock_data`
-  - Title: Stock data by ticker
-  - Description: Get detailed market data for a specific ticker on an exchange and date, including price, change, volume, value, market cap, and trades.
+### 7. `get_stock_snapshot`
+  - Title: Get stock market snapshot
+  - Description: Return detailed trading metrics for a single stock ticker on a specific exchange and trading date. Includes price open, last sale price, price change percentage, trading volume, traded value, number of trades, and market capitalization.
 
-  **Example Promt:** `#finmap-mcp Dominion Energy, stock data`
+  **Example Prompt:** `#finmap-mcp Dominion Energy, stock data`
   
   **Example Response:**
   ```json
@@ -412,11 +430,11 @@ npx finmap-mcp
   }
   ```
 
-### 8. `rank_stocks`
-  - Title: Rank stocks
-  - Description: Rank stocks on an exchange by a chosen metric (marketCap, priceChangePct, volume, value, numTrades) for a specific date with order and limit.
+### 8. `rank_exchange_companies`
+  - Title: Rank companies by market metric
+  - Description: Return companies ranked by a selected market metric on a specific exchange. Supported ranking metrics: market capitalization, price change percentage, trading volume, traded value, and number of trades. Results can be limited and optionally filtered by sector.
 
-  **Example Promt:** `#finmap-mcp UK, rank stocks by market cap`
+  **Example Prompt:** `#finmap-mcp UK, rank stocks by market cap`
   
   **Example Response:**
   ```json
@@ -488,11 +506,11 @@ npx finmap-mcp
   }
   ```
 
-### 9. `get_company_profile`
-  - Title: Company profile (US)
-  - Description: Get business description, industry, and background for a US-listed company by ticker.
+### 9. `get_company_profile_us`
+  - Title: Get US company profile
+  - Description: Return business description and background information for a US-listed company. Supported exchanges: NASDAQ, NYSE, and AMEX.
 
-  **Example Promt:** `#finmap-mcp Sprouts Farmers Market, get company profile`
+  **Example Prompt:** `#finmap-mcp Sprouts Farmers Market, get company profile`
   
   **Example Response:**
   ```json

--- a/biome.json
+++ b/biome.json
@@ -1,49 +1,61 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
-	"assist": {
-		"actions": {
-			"source": {
-				"useSortedKeys": "off"
-			}
-		},
-		"enabled": true
-	},
-	"files": {
-		"includes": ["!worker-configuration.d.ts", "!dist/index.js", "src/**/*"]
-	},
-	"formatter": {
-		"enabled": true,
-		"indentWidth": 2,
-		"lineWidth": 100
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true,
-			"style": {
-				"noInferrableTypes": "error",
-				"noNonNullAssertion": "off",
-				"noParameterAssign": "error",
-				"noUnusedTemplateLiteral": "error",
-				"noUselessElse": "error",
-				"useAsConstAssertion": "error",
-				"useDefaultParameterLast": "error",
-				"useEnumInitializers": "error",
-				"useNumberNamespace": "error",
-				"useSelfClosingElements": "error",
-				"useSingleVarDeclarator": "error"
-			},
-			"suspicious": {
-				"noConfusingVoidType": "off",
-				"noDebugger": "off",
-				"noExplicitAny": "off"
-			}
-		}
-	},
-	"root": false,
-	"vcs": {
-		"clientKind": "git",
-		"enabled": true,
-		"useIgnoreFile": true
-	}
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "useSortedKeys": "off"
+      }
+    },
+    "enabled": true
+  },
+  "files": {
+    "includes": [
+      "src/**/*",
+      "!worker-configuration.d.ts",
+      "!dist"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "noInferrableTypes": "error",
+        "noNonNullAssertion": "off",
+        "noParameterAssign": "error",
+        "noUnusedTemplateLiteral": "error",
+        "noUselessElse": "error",
+        "useAsConstAssertion": "error",
+        "useDefaultParameterLast": "error",
+        "useEnumInitializers": "error",
+        "useNumberNamespace": "error",
+        "useSelfClosingElements": "error",
+        "useSingleVarDeclarator": "error"
+      },
+      "suspicious": {
+        "noConfusingVoidType": "off",
+        "noDebugger": "off",
+        "noExplicitAny": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always"
+    }
+  },
+  "root": true,
+  "vcs": {
+    "clientKind": "git",
+    "enabled": true,
+    "useIgnoreFile": true
+  }
 }

--- a/gpt-actions.yaml
+++ b/gpt-actions.yaml
@@ -1,0 +1,588 @@
+openapi: 3.1.0
+info:
+  title: Finmap GPT API Wrapper
+  description: GPT Actions schema for Finmap API wrapper endpoints.
+  version: "1.0.0"
+servers:
+  - url: https://mcp.finmap.org
+paths:
+  /api/list-exchanges:
+    get:
+      operationId: list_supported_exchanges
+      summary: List supported stock exchanges
+      description: Return metadata for all supported stock exchanges in the Finmap dataset.
+      x-openai-isConsequential: false
+      responses:
+        "200":
+          description: Supported exchanges metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListExchangesResponse"
+  /api/list-sectors:
+    post:
+      operationId: list_exchange_sectors
+      summary: List sectors for a stock exchange
+      description: Return all business sectors available on an exchange and trading date.
+      x-openai-isConsequential: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ListSectorsRequest"
+      responses:
+        "200":
+          description: Sector list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListSectorsResponse"
+  /api/list-sector-companies:
+    post:
+      operationId: list_sector_companies
+      summary: List companies by sector
+      description: Return company tickers and names grouped by sector for an exchange and date.
+      x-openai-isConsequential: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ListSectorCompaniesRequest"
+      responses:
+        "200":
+          description: Companies grouped by sector.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListSectorCompaniesResponse"
+  /api/search-companies:
+    post:
+      operationId: search_exchange_companies
+      summary: Search companies by name or ticker
+      description: |
+        Search for companies on an exchange using a partial ticker symbol
+        or company name. Results are ranked by relevance.
+
+        Use this tool when the user:
+        • does not know the ticker symbol
+        • provides an incomplete company name
+        • wants to find companies matching a keyword
+      x-openai-isConsequential: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SearchCompaniesRequest"
+      responses:
+        "200":
+          description: Search results.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchCompaniesResponse"
+  /api/market-overview:
+    post:
+      operationId: analyze_market_overview
+      summary: Analyze market overview
+      description: Return aggregate market statistics and sector breakdown.
+      x-openai-isConsequential: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MarketOverviewRequest"
+      responses:
+        "200":
+          description: Market overview.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MarketOverviewResponse"
+  /api/sector-performance:
+    post:
+      operationId: analyze_sector_performance
+      summary: Analyze sector performance
+      description: Return aggregate metrics for sectors on an exchange.
+      x-openai-isConsequential: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SectorPerformanceRequest"
+      responses:
+        "200":
+          description: Sector performance.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SectorPerformanceResponse"
+  /api/rank-stocks:
+    post:
+      operationId: rank_exchange_companies
+      summary: Rank companies by market metric
+      description: |
+        Return companies ranked by a selected market metric such as
+        market capitalization, price change percentage, trading volume,
+        or traded value.
+
+        Use this tool when the user asks for:
+        • top companies
+        • largest companies
+        • biggest market cap
+        • top gainers or losers
+        • most traded stocks
+      x-openai-isConsequential: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RankStocksRequest"
+      responses:
+        "200":
+          description: Ranked companies.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RankStocksResponse"
+  /api/stock-snapshot:
+    post:
+      operationId: get_stock_snapshot
+      summary: Get stock market snapshot
+      description: |
+        Return detailed trading metrics for a single stock ticker on an exchange
+        and trading date, including price, change percentage, volume, traded
+        value, number of trades, and market capitalization.
+      x-openai-isConsequential: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StockSnapshotRequest"
+      responses:
+        "200":
+          description: Stock snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StockSnapshotResponse"
+  /api/company-profile:
+    post:
+      operationId: get_company_profile_us
+      summary: Get US company profile
+      description: Return profile information for a US-listed company.
+      x-openai-isConsequential: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompanyProfileRequest"
+      responses:
+        "200":
+          description: Company profile.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompanyProfileResponse"
+components:
+  schemas:
+    ExchangeDateInput:
+      type: object
+      required: [stockExchange]
+      description: |
+        Trading date for the query. If omitted, the latest available
+        trading date will be used automatically.
+      properties:
+        stockExchange:
+          type: string
+          enum: [amex, nasdaq, nyse, us-all, lse, moex, bist, hkex]
+        year:
+          type: integer
+          minimum: 2012
+        month:
+          type: integer
+          minimum: 1
+          maximum: 12
+        day:
+          type: integer
+          minimum: 1
+          maximum: 31
+
+    ListSectorsRequest:
+      type: object
+      required: [stockExchange]
+      properties:
+        stockExchange:
+          type: string
+          enum: [amex, nasdaq, nyse, us-all, lse, moex, bist, hkex]
+        year:
+          type: integer
+          minimum: 2012
+        month:
+          type: integer
+          minimum: 1
+          maximum: 12
+        day:
+          type: integer
+          minimum: 1
+          maximum: 31
+
+    ListSectorCompaniesRequest:
+      type: object
+      required: [stockExchange]
+      properties:
+        stockExchange:
+          type: string
+          enum: [amex, nasdaq, nyse, us-all, lse, moex, bist, hkex]
+        year:
+          type: integer
+          minimum: 2012
+        month:
+          type: integer
+          minimum: 1
+          maximum: 12
+        day:
+          type: integer
+          minimum: 1
+          maximum: 31
+        sector:
+          type: string
+        englishNames:
+          type: boolean
+          default: true
+
+    SearchCompaniesRequest:
+      type: object
+      required: [stockExchange, query]
+      properties:
+        stockExchange:
+          type: string
+          enum: [amex, nasdaq, nyse, us-all, lse, moex, bist, hkex]
+        year:
+          type: integer
+          minimum: 2012
+        month:
+          type: integer
+          minimum: 1
+          maximum: 12
+        day:
+          type: integer
+          minimum: 1
+          maximum: 31
+        query:
+          type: string
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 10
+          description: Maximum number of results returned.
+
+    MarketOverviewRequest:
+      type: object
+      required: [stockExchange]
+      properties:
+        stockExchange:
+          type: string
+          enum: [amex, nasdaq, nyse, us-all, lse, moex, bist, hkex]
+        year:
+          type: integer
+          minimum: 2012
+        month:
+          type: integer
+          minimum: 1
+          maximum: 12
+        day:
+          type: integer
+          minimum: 1
+          maximum: 31
+
+    SectorPerformanceRequest:
+      type: object
+      required: [stockExchange]
+      properties:
+        stockExchange:
+          type: string
+          enum: [amex, nasdaq, nyse, us-all, lse, moex, bist, hkex]
+        year:
+          type: integer
+          minimum: 2012
+        month:
+          type: integer
+          minimum: 1
+          maximum: 12
+        day:
+          type: integer
+          minimum: 1
+          maximum: 31
+        sector:
+          type: string
+
+    RankStocksRequest:
+      type: object
+      required: [stockExchange, sortBy]
+      properties:
+        stockExchange:
+          type: string
+          enum: [amex, nasdaq, nyse, us-all, lse, moex, bist, hkex]
+        year:
+          type: integer
+          minimum: 2012
+        month:
+          type: integer
+          minimum: 1
+          maximum: 12
+        day:
+          type: integer
+          minimum: 1
+          maximum: 31
+        sortBy:
+          type: string
+          enum: [priceChangePct, marketCap, value, volume, numTrades]
+        order:
+          type: string
+          enum: [asc, desc]
+          default: desc
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+          description: Maximum number of results returned.
+        sector:
+          type: string
+
+    StockSnapshotRequest:
+      type: object
+      required: [stockExchange, ticker]
+      properties:
+        stockExchange:
+          type: string
+          enum: [amex, nasdaq, nyse, us-all, lse, moex, bist, hkex]
+        year:
+          type: integer
+          minimum: 2012
+        month:
+          type: integer
+          minimum: 1
+          maximum: 12
+        day:
+          type: integer
+          minimum: 1
+          maximum: 31
+        ticker:
+          type: string
+
+    CompanyProfileRequest:
+      type: object
+      required: [exchange, ticker]
+      properties:
+        exchange:
+          type: string
+          enum: [amex, nasdaq, nyse]
+        ticker:
+          type: string
+
+    ListExchangesResponse:
+      type: object
+      properties:
+        info:
+          type: object
+          properties:
+            provider:
+              type: string
+        exchanges:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              country:
+                type: string
+              currency:
+                type: string
+              availableSince:
+                type: string
+              updateFrequency:
+                type: string
+
+    ListSectorsResponse:
+      type: object
+      properties:
+        date:
+          type: string
+        exchange:
+          type: string
+        currency:
+          type: string
+        sectors:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              itemsPerSector:
+                type: integer
+
+    ListSectorCompaniesResponse:
+      type: object
+      properties:
+        date:
+          type: string
+        exchange:
+          type: string
+        currency:
+          type: string
+        sectors:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              properties:
+                ticker:
+                  type: string
+                name:
+                  type: string
+
+    SearchCompaniesResponse:
+      type: object
+      properties:
+        date:
+          type: string
+        exchange:
+          type: string
+        query:
+          type: string
+        matches:
+          type: array
+          items:
+            type: object
+            properties:
+              ticker:
+                type: string
+              name:
+                type: string
+              sector:
+                type: string
+              score:
+                type: integer
+
+    MarketOverviewResponse:
+      type: object
+      properties:
+        date:
+          type: string
+        exchange:
+          type: string
+        currency:
+          type: string
+        marketTotal:
+          type: object
+          properties:
+            name:
+              type: string
+            marketCap:
+              type: number
+        sectors:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              marketCap:
+                type: number
+
+    SectorPerformanceResponse:
+      type: object
+      properties:
+        date:
+          type: string
+        exchange:
+          type: string
+        currency:
+          type: string
+        sectors:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              marketCap:
+                type: number
+
+    RankStocksResponse:
+      type: object
+      properties:
+        date:
+          type: string
+        exchange:
+          type: string
+        sortBy:
+          type: string
+        order:
+          type: string
+        limit:
+          type: integer
+        count:
+          type: integer
+        stocks:
+          type: array
+          items:
+            type: object
+            properties:
+              ticker:
+                type: string
+              name:
+                type: string
+              sector:
+                type: string
+              marketCap:
+                type: number
+              priceChangePct:
+                type: number
+
+    StockSnapshotResponse:
+      type: object
+      properties:
+        exchange:
+          type: string
+        country:
+          type: string
+        ticker:
+          type: string
+        nameEng:
+          type: string
+        priceLastSale:
+          type: number
+        priceChangePct:
+          type: number
+        volume:
+          type: number
+        value:
+          type: number
+        numTrades:
+          type: number
+        marketCap:
+          type: number
+
+    CompanyProfileResponse:
+      type: object
+      properties:
+        data:
+          type: object
+        charts:
+          type: object

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,545 @@
+import { z } from "zod";
+import {
+	BASE_URL,
+	EXCHANGE_INFO,
+	INDICES,
+	INFO,
+	type SortField,
+} from "./domain/constants.js";
+import {
+	companyProfileSchema,
+	listSectorsSchema,
+	listTickersSchema,
+	marketOverviewSchema,
+	rankStocksSchema,
+	searchCompaniesSchema,
+	sectorsOverviewSchema,
+	stockDataSchema,
+} from "./domain/schemas.js";
+import { fetchMarketData, fetchSecurityInfo } from "./infra/github-client.js";
+
+export {
+	companyProfileSchema,
+	listSectorsSchema,
+	listTickersSchema,
+	marketOverviewSchema,
+	rankStocksSchema,
+	searchCompaniesSchema,
+	sectorsOverviewSchema,
+	stockDataSchema,
+};
+
+type RankedStock = {
+	ticker: string;
+	name: string;
+	sector: string;
+	priceLastSale: number;
+	priceChangePct: number;
+	marketCap: number;
+	volume: number;
+	value: number;
+	numTrades: number;
+};
+
+type SearchMatch = {
+	ticker: string;
+	name: string;
+	sector: string;
+	score: number;
+};
+
+function createCharts(exchange: string, date?: string) {
+	return {
+		histogram: `${BASE_URL}/?chart=histogram&data=marketcap&currency=USD&exchange=${exchange}`,
+		treemap: `${BASE_URL}/?chart=treemap&data=marketcap&currency=USD&exchange=${exchange}${date ? `&date=${date.replaceAll("-", "/")}` : ""}`,
+	};
+}
+
+function calculateMatchScore(
+	ticker: string,
+	name: string,
+	searchTerm: string,
+): number {
+	const tickerLower = ticker.toLowerCase();
+	const nameLower = name.toLowerCase();
+
+	if (tickerLower === searchTerm) return 100;
+	if (tickerLower.startsWith(searchTerm)) return 90;
+	if (tickerLower.includes(searchTerm)) return 80;
+	if (nameLower.includes(searchTerm)) return 70;
+
+	return 0;
+}
+
+function buildDateString(year?: number, month?: number, day?: number): string {
+	const currentDate = new Date();
+	const y = year ?? currentDate.getFullYear();
+	const m = month ?? currentDate.getMonth() + 1;
+	const d = day ?? currentDate.getDate();
+	return `${y.toString()}/${m.toString().padStart(2, "0")}/${d.toString().padStart(2, "0")}`;
+}
+
+function validateAndFormatDate(dateString: string): string {
+	const date = dateString.replaceAll("/", "-");
+	z.string().date().parse(date);
+
+	const dayOfWeek = new Date(date).getDay();
+	if (dayOfWeek === 0 || dayOfWeek === 6) {
+		throw new Error("Data is only available for work days (Monday to Friday)");
+	}
+
+	return date;
+}
+
+function getDate(year?: number, month?: number, day?: number): string {
+	return validateAndFormatDate(buildDateString(year, month, day));
+}
+
+function keepTopK<T>(
+	items: Iterable<T>,
+	limit: number,
+	isBetter: (candidate: T, current: T) => boolean,
+): T[] {
+	if (limit <= 0) return [];
+
+	const heap: T[] = [];
+	const isWorse = (a: T, b: T) => isBetter(b, a);
+
+	const swap = (i: number, j: number) => {
+		const tmp = heap[i];
+		heap[i] = heap[j];
+		heap[j] = tmp;
+	};
+
+	const bubbleUp = (index: number) => {
+		let idx = index;
+		while (idx > 0) {
+			const parent = Math.floor((idx - 1) / 2);
+			if (!isWorse(heap[idx], heap[parent])) break;
+			swap(idx, parent);
+			idx = parent;
+		}
+	};
+
+	const bubbleDown = (index: number) => {
+		let idx = index;
+		while (true) {
+			const left = idx * 2 + 1;
+			const right = left + 1;
+			let smallest = idx;
+
+			if (left < heap.length && isWorse(heap[left], heap[smallest])) {
+				smallest = left;
+			}
+			if (right < heap.length && isWorse(heap[right], heap[smallest])) {
+				smallest = right;
+			}
+			if (smallest === idx) break;
+			swap(idx, smallest);
+			idx = smallest;
+		}
+	};
+
+	for (const item of items) {
+		if (heap.length < limit) {
+			heap.push(item);
+			bubbleUp(heap.length - 1);
+			continue;
+		}
+
+		if (isBetter(item, heap[0])) {
+			heap[0] = item;
+			bubbleDown(0);
+		}
+	}
+
+	heap.sort((a, b) => (isBetter(a, b) ? -1 : isBetter(b, a) ? 1 : 0));
+	return heap;
+}
+
+export function listExchanges() {
+	const exchanges = Object.entries(EXCHANGE_INFO).map(([id, info]) => ({
+		id,
+		...info,
+	}));
+	return { info: INFO, exchanges };
+}
+
+export async function listSectors(input: z.infer<typeof listSectorsSchema>) {
+	const formattedDate = getDate(input.year, input.month, input.day);
+	const marketDataResponse = await fetchMarketData(
+		input.stockExchange,
+		formattedDate,
+	);
+	const sectorCounts: Record<string, number> = {};
+	for (const item of marketDataResponse.securities.data) {
+		if (item[INDICES.TYPE] !== "sector" && item[INDICES.SECTOR]) {
+			sectorCounts[item[INDICES.SECTOR] as string] =
+				(sectorCounts[item[INDICES.SECTOR] as string] || 0) + 1;
+		}
+	}
+	const sectors = Object.entries(sectorCounts).map(([name, count]) => ({
+		name,
+		itemsPerSector: count,
+	}));
+	return {
+		info: INFO,
+		date: formattedDate,
+		exchange: input.stockExchange.toUpperCase(),
+		currency: EXCHANGE_INFO[input.stockExchange].currency,
+		sectors,
+	};
+}
+
+export async function listTickers(input: z.infer<typeof listTickersSchema>) {
+	const formattedDate = getDate(input.year, input.month, input.day);
+	const marketDataResponse = await fetchMarketData(
+		input.stockExchange,
+		formattedDate,
+	);
+	const sectorGroups: Record<
+		string,
+		Array<{ ticker: string; name: string }>
+	> = {};
+	for (const item of marketDataResponse.securities.data) {
+		if (
+			item[INDICES.TYPE] !== "sector" &&
+			item[INDICES.SECTOR] &&
+			(!input.sector || item[INDICES.SECTOR] === input.sector)
+		) {
+			const sectorName = item[INDICES.SECTOR] as string;
+			const ticker = item[INDICES.TICKER] as string;
+			const name = input.englishNames
+				? (item[INDICES.NAME_ENG] as string)
+				: ((item[INDICES.NAME_ORIGINAL_SHORT] ||
+						item[INDICES.NAME_ENG]) as string);
+			if (ticker && name) {
+				if (!sectorGroups[sectorName]) sectorGroups[sectorName] = [];
+				sectorGroups[sectorName].push({ ticker, name });
+			}
+		}
+	}
+	for (const companies of Object.values(sectorGroups)) {
+		companies.sort((a, b) => a.ticker.localeCompare(b.ticker));
+	}
+	return {
+		info: INFO,
+		date: formattedDate,
+		exchange: input.stockExchange.toUpperCase(),
+		currency: EXCHANGE_INFO[input.stockExchange].currency,
+		sectors: sectorGroups,
+	};
+}
+
+export async function searchCompanies(
+	input: z.infer<typeof searchCompaniesSchema>,
+) {
+	const formattedDate = getDate(input.year, input.month, input.day);
+	const marketDataResponse = await fetchMarketData(
+		input.stockExchange,
+		formattedDate,
+	);
+	const searchTerm = input.query.toLowerCase();
+	const matches: SearchMatch[] = [];
+	for (const item of marketDataResponse.securities.data) {
+		if (item[INDICES.TYPE] === "sector" || !item[INDICES.SECTOR]) continue;
+		const ticker = item[INDICES.TICKER] as string;
+		const name = item[INDICES.NAME_ENG] as string;
+		const score = calculateMatchScore(ticker, name, searchTerm);
+		if (score <= 0) continue;
+		matches.push({
+			ticker,
+			name,
+			sector: item[INDICES.SECTOR] as string,
+			score,
+		});
+	}
+
+	const topMatches = keepTopK(matches, input.limit, (candidate, current) => {
+		if (candidate.score !== current.score)
+			return candidate.score > current.score;
+		return candidate.ticker.localeCompare(current.ticker) < 0;
+	});
+
+	return {
+		info: INFO,
+		date: formattedDate,
+		exchange: input.stockExchange.toUpperCase(),
+		currency: EXCHANGE_INFO[input.stockExchange].currency,
+		query: input.query,
+		matches: topMatches,
+	};
+}
+
+export async function getMarketOverview(
+	input: z.infer<typeof marketOverviewSchema>,
+) {
+	const formattedDate = getDate(input.year, input.month, input.day);
+	const marketDataResponse = await fetchMarketData(
+		input.stockExchange,
+		formattedDate,
+	);
+
+	const sectorItems = marketDataResponse.securities.data.filter(
+		(item) => item[INDICES.TYPE] === "sector",
+	);
+
+	let marketTotal = {};
+	const sectors: Array<Record<string, unknown>> = [];
+	for (const item of sectorItems) {
+		const sectorData = {
+			name: item[INDICES.TICKER],
+			marketCap: item[INDICES.MARKET_CAP],
+			marketCapChangePct: item[INDICES.PRICE_CHANGE_PCT],
+			volume: item[INDICES.VOLUME],
+			value: item[INDICES.VALUE],
+			numTrades: item[INDICES.NUM_TRADES],
+			itemsPerSector: item[INDICES.ITEMS_PER_SECTOR],
+		};
+		if (item[INDICES.SECTOR] === "") marketTotal = sectorData;
+		else sectors.push(sectorData);
+	}
+
+	return {
+		info: INFO,
+		charts: createCharts(input.stockExchange, formattedDate),
+		date: formattedDate,
+		exchange: input.stockExchange.toUpperCase(),
+		currency: EXCHANGE_INFO[input.stockExchange].currency,
+		marketTotal,
+		sectors,
+	};
+}
+
+export async function getSectorsOverview(
+	input: z.infer<typeof sectorsOverviewSchema>,
+) {
+	const formattedDate = getDate(input.year, input.month, input.day);
+	const marketDataResponse = await fetchMarketData(
+		input.stockExchange,
+		formattedDate,
+	);
+
+	const sectors = marketDataResponse.securities.data
+		.filter(
+			(item) => item[INDICES.TYPE] === "sector" && item[INDICES.SECTOR] !== "",
+		)
+		.filter((item) => !input.sector || item[INDICES.TICKER] === input.sector)
+		.map((item) => ({
+			name: item[INDICES.TICKER],
+			marketCap: item[INDICES.MARKET_CAP],
+			marketCapChangePct: item[INDICES.PRICE_CHANGE_PCT],
+			volume: item[INDICES.VOLUME],
+			value: item[INDICES.VALUE],
+			numTrades: item[INDICES.NUM_TRADES],
+			itemsPerSector: item[INDICES.ITEMS_PER_SECTOR],
+		}));
+
+	return {
+		info: INFO,
+		charts: createCharts(input.stockExchange, formattedDate),
+		date: formattedDate,
+		exchange: input.stockExchange.toUpperCase(),
+		currency: EXCHANGE_INFO[input.stockExchange].currency,
+		sectors,
+	};
+}
+
+export async function rankStocks(input: z.infer<typeof rankStocksSchema>) {
+	const formattedDate = getDate(input.year, input.month, input.day);
+	const marketDataResponse = await fetchMarketData(
+		input.stockExchange,
+		formattedDate,
+	);
+
+	const stocks: RankedStock[] = [];
+	for (const item of marketDataResponse.securities.data) {
+		if (item[INDICES.TYPE] === "sector" || item[INDICES.SECTOR] === "")
+			continue;
+		if (input.sector && item[INDICES.SECTOR] !== input.sector) continue;
+		stocks.push({
+			ticker: item[INDICES.TICKER] as string,
+			name: item[INDICES.NAME_ENG] as string,
+			sector: item[INDICES.SECTOR] as string,
+			priceLastSale: item[INDICES.PRICE_LAST_SALE] as number,
+			priceChangePct: item[INDICES.PRICE_CHANGE_PCT] as number,
+			marketCap: item[INDICES.MARKET_CAP] as number,
+			volume: item[INDICES.VOLUME] as number,
+			value: item[INDICES.VALUE] as number,
+			numTrades: item[INDICES.NUM_TRADES] as number,
+		});
+	}
+
+	const rankedStocks = keepTopK(stocks, input.limit, (candidate, current) => {
+		const candidateValue = candidate[input.sortBy as SortField] as number;
+		const currentValue = current[input.sortBy as SortField] as number;
+		if (candidateValue !== currentValue) {
+			return input.order === "desc"
+				? candidateValue > currentValue
+				: candidateValue < currentValue;
+		}
+		return candidate.ticker.localeCompare(current.ticker) < 0;
+	});
+
+	return {
+		info: INFO,
+		charts: createCharts(input.stockExchange, formattedDate),
+		date: formattedDate,
+		exchange: input.stockExchange.toUpperCase(),
+		currency: EXCHANGE_INFO[input.stockExchange].currency,
+		sortBy: input.sortBy,
+		order: input.order,
+		limit: input.limit,
+		count: rankedStocks.length,
+		stocks: rankedStocks,
+	};
+}
+
+export async function getStockData(input: z.infer<typeof stockDataSchema>) {
+	const formattedDate = getDate(input.year, input.month, input.day);
+	const marketDataResponse = await fetchMarketData(
+		input.stockExchange,
+		formattedDate,
+	);
+
+	const stockData = marketDataResponse.securities.data.find(
+		(item) =>
+			item[INDICES.TYPE] !== "sector" && item[INDICES.TICKER] === input.ticker,
+	);
+	if (!stockData) {
+		throw new Error(
+			`Ticker ${input.ticker} not found on ${input.stockExchange} for date ${formattedDate}`,
+		);
+	}
+
+	return {
+		info: INFO,
+		charts: createCharts(input.stockExchange, formattedDate),
+		exchange: stockData[INDICES.EXCHANGE],
+		country: stockData[INDICES.COUNTRY],
+		currency: EXCHANGE_INFO[input.stockExchange].currency,
+		sector: stockData[INDICES.SECTOR],
+		ticker: stockData[INDICES.TICKER],
+		nameEng: stockData[INDICES.NAME_ENG],
+		nameOriginal: stockData[INDICES.NAME_ORIGINAL],
+		priceOpen: stockData[INDICES.PRICE_OPEN],
+		priceLastSale: stockData[INDICES.PRICE_LAST_SALE],
+		priceChangePct: stockData[INDICES.PRICE_CHANGE_PCT],
+		volume: stockData[INDICES.VOLUME],
+		value: stockData[INDICES.VALUE],
+		numTrades: stockData[INDICES.NUM_TRADES],
+		marketCap: stockData[INDICES.MARKET_CAP],
+		listedFrom: stockData[INDICES.LISTED_FROM],
+		listedTill: stockData[INDICES.LISTED_TILL],
+	};
+}
+
+export async function getCompanyProfile(
+	input: z.infer<typeof companyProfileSchema>,
+) {
+	const securityInfo = (await fetchSecurityInfo(
+		input.exchange,
+		input.ticker,
+	)) as Record<string, unknown>;
+	return {
+		info: INFO,
+		charts: createCharts(input.exchange),
+		...securityInfo,
+	};
+}
+
+export function getApiOpenApiSpec(baseUrl: string) {
+	return {
+		openapi: "3.1.0",
+		info: {
+			title: "Finmap GPT API",
+			description:
+				"Compact HTTP API for GPT Actions backed by Finmap MCP logic",
+			version: "1.0.0",
+		},
+		servers: [{ url: baseUrl }],
+		paths: {
+			"/api/list-exchanges": {
+				get: {
+					operationId: "list_supported_exchanges",
+					summary: "List supported stock exchanges",
+					description:
+						"Return metadata for all supported stock exchanges in the Finmap dataset.",
+					"x-openai-isConsequential": false,
+				},
+			},
+			"/api/list-sectors": {
+				post: {
+					operationId: "list_exchange_sectors",
+					summary: "List sectors for a stock exchange",
+					description:
+						"Return all business sectors available on an exchange and trading date.",
+					"x-openai-isConsequential": false,
+				},
+			},
+			"/api/list-sector-companies": {
+				post: {
+					operationId: "list_sector_companies",
+					summary: "List companies by sector",
+					description:
+						"Return company tickers and names grouped by sector for an exchange and date.",
+					"x-openai-isConsequential": false,
+				},
+			},
+			"/api/search-companies": {
+				post: {
+					operationId: "search_exchange_companies",
+					summary: "Search companies by name or ticker",
+					description:
+						"Search for companies on an exchange using a partial ticker symbol or company name. Results are ranked by relevance. Use when the user does not know the ticker symbol, provides an incomplete company name, or wants companies matching a keyword.",
+					"x-openai-isConsequential": false,
+				},
+			},
+			"/api/market-overview": {
+				post: {
+					operationId: "analyze_market_overview",
+					summary: "Analyze market overview",
+					description:
+						"Return aggregate market statistics with sector-level breakdown.",
+					"x-openai-isConsequential": false,
+				},
+			},
+			"/api/sector-performance": {
+				post: {
+					operationId: "analyze_sector_performance",
+					summary: "Analyze sector performance",
+					description:
+						"Return aggregated metrics for sectors on an exchange and date.",
+					"x-openai-isConsequential": false,
+				},
+			},
+			"/api/rank-stocks": {
+				post: {
+					operationId: "rank_exchange_companies",
+					summary: "Rank companies by market metric",
+					description:
+						"Return companies ranked by market capitalization, price change percentage, traded value, volume, or trades. Use for top companies, biggest market cap, top gainers/losers, and most traded stocks.",
+					"x-openai-isConsequential": false,
+				},
+			},
+			"/api/stock-snapshot": {
+				post: {
+					operationId: "get_stock_snapshot",
+					summary: "Get stock market snapshot",
+					description:
+						"Return detailed trading metrics for a single stock ticker on an exchange and trading date, including price, change percentage, volume, traded value, number of trades, and market capitalization.",
+					"x-openai-isConsequential": false,
+				},
+			},
+			"/api/company-profile": {
+				post: {
+					operationId: "get_company_profile_us",
+					summary: "Get US company profile",
+					description:
+						"Return business description and company metadata for US-listed tickers.",
+					"x-openai-isConsequential": false,
+				},
+			},
+		},
+	};
+}

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,85 +1,25 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
+import {
+	companyProfileSchema,
+	getCompanyProfile,
+	getMarketOverview,
+	getSectorsOverview,
+	getStockData,
+	listExchanges,
+	listSectors,
+	listSectorsSchema,
+	listTickers,
+	listTickersSchema,
+	marketOverviewSchema,
+	rankStocks,
+	rankStocksSchema,
+	searchCompanies,
+	searchCompaniesSchema,
+	sectorsOverviewSchema,
+	stockDataSchema,
+} from "./api.js";
 
-const BASE_URL = "https://finmap.org";
-const DATA_BASE_URL = "https://raw.githubusercontent.com/finmap-org";
-
-const INFO = {
-	provider: "finmap.org",
-	description:
-		"Discover interactive stock charts and curated news at finmap.org",
-	github: "https://github.com/finmap-org",
-	donate: {
-		patreon: "https://patreon.com/finmap",
-		boosty: "https://boosty.to/finmap",
-	},
-	issues: "https://github.com/finmap-org/mcp-server/issues",
-	feedback: "contact@finmap.org",
-};
-
-const STOCK_EXCHANGES = [
-	"amex",
-	"nasdaq",
-	"nyse",
-	"us-all",
-	"lse",
-	"moex",
-	"bist",
-	"hkex",
-] as const;
-const US_EXCHANGES = ["amex", "nasdaq", "nyse"] as const;
-const SORT_FIELDS = [
-	"priceChangePct",
-	"marketCap",
-	"value",
-	"volume",
-	"numTrades",
-] as const;
-const SORT_ORDERS = ["asc", "desc"] as const;
-
-type StockExchange = (typeof STOCK_EXCHANGES)[number];
-type USExchange = (typeof US_EXCHANGES)[number];
-type SortField = (typeof SORT_FIELDS)[number];
-type SortOrder = (typeof SORT_ORDERS)[number];
-
-const INDICES = {
-	EXCHANGE: 0,
-	COUNTRY: 1,
-	TYPE: 2,
-	SECTOR: 3,
-	INDUSTRY: 4,
-	CURRENCY_ID: 5,
-	TICKER: 6,
-	NAME_ENG: 7,
-	NAME_ENG_SHORT: 8,
-	NAME_ORIGINAL: 9,
-	NAME_ORIGINAL_SHORT: 10,
-	PRICE_OPEN: 11,
-	PRICE_LAST_SALE: 12,
-	PRICE_CHANGE_PCT: 13,
-	VOLUME: 14,
-	VALUE: 15,
-	NUM_TRADES: 16,
-	MARKET_CAP: 17,
-	LISTED_FROM: 18,
-	LISTED_TILL: 19,
-	WIKI_PAGE_ID_ENG: 20,
-	WIKI_PAGE_ID_ORIGINAL: 21,
-	ITEMS_PER_SECTOR: 22,
-} as const;
-
-const EXCHANGE_TO_COUNTRY_MAP: Record<StockExchange, string> = {
-	amex: "us",
-	nasdaq: "us",
-	nyse: "us",
-	"us-all": "us",
-	lse: "uk",
-	moex: "russia",
-	bist: "turkey",
-	hkex: "hongkong",
-};
-
-function createResponse(data: any) {
+function createResponse(data: unknown) {
 	return {
 		content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
 	};
@@ -91,183 +31,18 @@ function createErrorResponse(error: unknown) {
 	);
 }
 
-function createCharts(exchange: string, date?: string) {
-	return {
-		histogram: `${BASE_URL}/?chart=histogram&data=marketcap&currency=USD&exchange=${exchange}`,
-		treemap: `${BASE_URL}/?chart=treemap&data=marketcap&currency=USD&exchange=${exchange}${date ? `&date=${date.replaceAll("-", "/")}` : ""}`,
-	};
-}
-
-function calculateMatchScore(
-	ticker: string,
-	name: string,
-	searchTerm: string,
-): number {
-	const tickerLower = ticker.toLowerCase();
-	const nameLower = name.toLowerCase();
-
-	if (tickerLower === searchTerm) return 100;
-	if (tickerLower.startsWith(searchTerm)) return 90;
-	if (tickerLower.includes(searchTerm)) return 80;
-	if (nameLower.includes(searchTerm)) return 70;
-
-	return 0;
-}
-
-const EXCHANGE_INFO: Record<
-	StockExchange,
-	{
-		name: string;
-		country: string;
-		currency: string;
-		availableSince: string;
-		updateFrequency: string;
-	}
-> = {
-	amex: {
-		name: "American Stock Exchange",
-		country: "United States",
-		currency: "USD",
-		availableSince: "2024-12-09",
-		updateFrequency: "Daily",
-	},
-	nasdaq: {
-		name: "NASDAQ Stock Market",
-		country: "United States",
-		currency: "USD",
-		availableSince: "2024-12-09",
-		updateFrequency: "Daily",
-	},
-	nyse: {
-		name: "New York Stock Exchange",
-		country: "United States",
-		currency: "USD",
-		availableSince: "2024-12-09",
-		updateFrequency: "Daily",
-	},
-	"us-all": {
-		name: "US Combined (AMEX + NASDAQ + NYSE)",
-		country: "United States",
-		currency: "USD",
-		availableSince: "2024-12-09",
-		updateFrequency: "Daily",
-	},
-	lse: {
-		name: "London Stock Exchange",
-		country: "United Kingdom",
-		currency: "GBP",
-		availableSince: "2025-02-07",
-		updateFrequency: "Hourly (weekdays)",
-	},
-	moex: {
-		name: "Moscow Exchange",
-		country: "Russia",
-		currency: "RUB",
-		availableSince: "2011-12-19",
-		updateFrequency: "Every 15 minutes (weekdays)",
-	},
-	bist: {
-		name: "Borsa Istanbul",
-		country: "Turkey",
-		currency: "TRY",
-		availableSince: "2015-11-30",
-		updateFrequency: "Every two months",
-	},
-	hkex: {
-		name: "Hong Kong Stock Exchange",
-		country: "Hong Kong",
-		currency: "HKD",
-		availableSince: "2025-09-29",
-		updateFrequency: "Every 30 minutes (weekdays)",
-	},
-};
-
-const exchangeSchema = z
-	.enum(STOCK_EXCHANGES)
-	.describe(
-		"Stock exchange: amex, nasdaq, nyse, us-all, lse, moex, bist, hkex",
-	);
-const dateSchema = {
-	year: z.number().int().min(2012).optional(),
-	month: z.number().int().min(1).max(12).optional(),
-	day: z.number().int().min(1).max(31).optional(),
-};
-
-function buildDateString(year?: number, month?: number, day?: number): string {
-	const currentDate = new Date();
-	const y = year ?? currentDate.getFullYear();
-	const m = month ?? currentDate.getMonth() + 1;
-	const d = day ?? currentDate.getDate();
-	return `${y.toString()}/${m.toString().padStart(2, "0")}/${d.toString().padStart(2, "0")}`;
-}
-
-function validateAndFormatDate(dateString: string): string {
-	const date = dateString.replaceAll("/", "-");
-	z.string().date().parse(date);
-
-	const dayOfWeek = new Date(date).getDay();
-	if (dayOfWeek === 0 || dayOfWeek === 6) {
-		throw new Error("Data is only available for work days (Monday to Friday)");
-	}
-
-	return date;
-}
-
-function getDate(year?: number, month?: number, day?: number): string {
-	const dateString = buildDateString(year, month, day);
-	return validateAndFormatDate(dateString);
-}
-
-async function fetchMarketData(
-	stockExchange: StockExchange,
-	formattedDate: string,
-): Promise<{ securities: { data: any[][] } }> {
-	const country = EXCHANGE_TO_COUNTRY_MAP[stockExchange];
-	const date = formattedDate.replaceAll("-", "/");
-	const url = `${DATA_BASE_URL}/data-${country}/refs/heads/main/marketdata/${date}/${stockExchange}.json`;
-
-	const response = await fetch(url);
-	if (response.status === 404) {
-		throw new Error(
-			`Not found, try another date. The date must be on or after ${EXCHANGE_INFO[stockExchange].availableSince} for ${stockExchange}`,
-		);
-	}
-
-	return response.json();
-}
-
-async function fetchSecurityInfo(
-	exchange: USExchange,
-	ticker: string,
-): Promise<Record<string, any>> {
-	const firstLetter = ticker.charAt(0).toUpperCase();
-	const url = `${DATA_BASE_URL}/data-us/refs/heads/main/securities/${exchange}/${firstLetter}/${ticker}.json`;
-
-	const response = await fetch(url);
-	if (response.status === 404) {
-		throw new Error(`Security ${ticker} not found on ${exchange}`);
-	}
-
-	const data = (await response.json()) as any;
-	return data;
-}
-
 export function registerFinmapTools(server: McpServer) {
 	server.registerTool(
-		"list_exchanges",
+		"list_supported_exchanges",
 		{
-			title: "List exchanges",
+			title: "List supported stock exchanges",
 			description:
-				"Return supported exchanges with IDs, names, country, currency, earliest available date, and update frequency.",
+				"Return metadata for all supported stock exchanges in the Finmap dataset, including exchange ID, exchange name, country, currency, earliest available historical data date, and update frequency.",
 			inputSchema: {},
 		},
 		async () => {
 			try {
-				const exchanges = Object.entries(EXCHANGE_INFO).map(([id, info]) => ({
-					id,
-					...info,
-				}));
-				return createResponse({ info: INFO, exchanges });
+				return createResponse(listExchanges());
 			} catch (error) {
 				return createErrorResponse(error);
 			}
@@ -275,50 +50,18 @@ export function registerFinmapTools(server: McpServer) {
 	);
 
 	server.registerTool(
-		"list_sectors",
+		"list_exchange_sectors",
 		{
-			title: "List sectors",
+			title: "List sectors for a stock exchange",
 			description:
-				"List available business sectors for an exchange on a specific date, including item counts.",
-			inputSchema: { stockExchange: exchangeSchema, ...dateSchema },
+				"Return all business sectors available on a specific exchange and trading date. Each sector includes the number of companies in that sector.",
+			inputSchema: listSectorsSchema.shape,
 		},
-		async ({
-			stockExchange,
-			year,
-			month,
-			day,
-		}: {
-			stockExchange: StockExchange;
-			year?: number;
-			month?: number;
-			day?: number;
-		}) => {
+		async (input) => {
 			try {
-				const formattedDate = getDate(year, month, day);
-				const marketDataResponse = await fetchMarketData(
-					stockExchange,
-					formattedDate,
+				return createResponse(
+					await listSectors(listSectorsSchema.parse(input)),
 				);
-
-				const sectorCounts: Record<string, number> = {};
-				marketDataResponse.securities.data.forEach((item: any[]) => {
-					if (item[INDICES.TYPE] !== "sector" && item[INDICES.SECTOR]) {
-						sectorCounts[item[INDICES.SECTOR]] =
-							(sectorCounts[item[INDICES.SECTOR]] || 0) + 1;
-					}
-				});
-
-				const sectors = Object.entries(sectorCounts).map(([name, count]) => ({
-					name,
-					itemsPerSector: count,
-				}));
-				return createResponse({
-					info: INFO,
-					date: formattedDate,
-					exchange: stockExchange.toUpperCase(),
-					currency: EXCHANGE_INFO[stockExchange as StockExchange].currency,
-					sectors,
-				});
 			} catch (error) {
 				return createErrorResponse(error);
 			}
@@ -326,78 +69,18 @@ export function registerFinmapTools(server: McpServer) {
 	);
 
 	server.registerTool(
-		"list_tickers",
+		"list_sector_companies",
 		{
-			title: "List tickers by sector",
+			title: "List companies by sector",
 			description:
-				"Return company tickers and names for an exchange on a specific date, grouped by sector.",
-			inputSchema: {
-				stockExchange: exchangeSchema,
-				...dateSchema,
-				sector: z.string().optional().describe("Filter by specific sector"),
-				englishNames: z
-					.boolean()
-					.default(true)
-					.describe("Use English names if available"),
-			},
+				"Return company tickers and names grouped by sector for an exchange on a specific trading date. Optionally filter results by a single sector.",
+			inputSchema: listTickersSchema.shape,
 		},
-		async ({
-			stockExchange,
-			year,
-			month,
-			day,
-			sector,
-			englishNames,
-		}: {
-			stockExchange: StockExchange;
-			year?: number;
-			month?: number;
-			day?: number;
-			sector?: string;
-			englishNames?: boolean;
-		}) => {
+		async (input) => {
 			try {
-				const formattedDate = getDate(year, month, day);
-				const marketDataResponse = await fetchMarketData(
-					stockExchange,
-					formattedDate,
+				return createResponse(
+					await listTickers(listTickersSchema.parse(input)),
 				);
-
-				const sectorGroups: Record<
-					string,
-					Array<{ ticker: string; name: string }>
-				> = {};
-
-				marketDataResponse.securities.data.forEach((item: any[]) => {
-					if (
-						item[INDICES.TYPE] !== "sector" &&
-						item[INDICES.SECTOR] &&
-						(!sector || item[INDICES.SECTOR] === sector)
-					) {
-						const sectorName = item[INDICES.SECTOR];
-						const ticker = item[INDICES.TICKER];
-						const name = englishNames
-							? item[INDICES.NAME_ENG]
-							: item[INDICES.NAME_ORIGINAL_SHORT] || item[INDICES.NAME_ENG];
-
-						if (ticker && name) {
-							if (!sectorGroups[sectorName]) sectorGroups[sectorName] = [];
-							sectorGroups[sectorName].push({ ticker, name });
-						}
-					}
-				});
-
-				Object.values(sectorGroups).forEach((companies) => {
-					companies.sort((a, b) => a.ticker.localeCompare(b.ticker));
-				});
-
-				return createResponse({
-					info: INFO,
-					date: formattedDate,
-					exchange: stockExchange.toUpperCase(),
-					currency: EXCHANGE_INFO[stockExchange as StockExchange].currency,
-					sectors: sectorGroups,
-				});
 			} catch (error) {
 				return createErrorResponse(error);
 			}
@@ -405,76 +88,18 @@ export function registerFinmapTools(server: McpServer) {
 	);
 
 	server.registerTool(
-		"search_companies",
+		"search_exchange_companies",
 		{
-			title: "Search companies",
+			title: "Search companies by name or ticker",
 			description:
-				"Find companies by partial name or ticker on an exchange and return best matches",
-			inputSchema: {
-				stockExchange: exchangeSchema,
-				...dateSchema,
-				query: z
-					.string()
-					.describe("Search term (partial ticker or company name)"),
-				limit: z
-					.number()
-					.int()
-					.min(1)
-					.max(50)
-					.default(10)
-					.describe("Maximum results"),
-			},
+				"Search for companies on a specific exchange by partial ticker symbol or company name. Results are ranked by relevance using ticker and name similarity.",
+			inputSchema: searchCompaniesSchema.shape,
 		},
-		async ({
-			stockExchange,
-			year,
-			month,
-			day,
-			query,
-			limit,
-		}: {
-			stockExchange: StockExchange;
-			year?: number;
-			month?: number;
-			day?: number;
-			query: string;
-			limit?: number;
-		}) => {
+		async (input) => {
 			try {
-				const formattedDate = getDate(year, month, day);
-				const marketDataResponse = await fetchMarketData(
-					stockExchange,
-					formattedDate,
+				return createResponse(
+					await searchCompanies(searchCompaniesSchema.parse(input)),
 				);
-				const searchTerm = query.toLowerCase();
-
-				const matches = marketDataResponse.securities.data
-					.filter(
-						(item: any[]) =>
-							item[INDICES.TYPE] !== "sector" && item[INDICES.SECTOR],
-					)
-					.map((item: any[]) => ({
-						ticker: item[INDICES.TICKER],
-						name: item[INDICES.NAME_ENG],
-						sector: item[INDICES.SECTOR],
-						score: calculateMatchScore(
-							item[INDICES.TICKER],
-							item[INDICES.NAME_ENG],
-							searchTerm,
-						),
-					}))
-					.filter((match) => match.score > 0)
-					.sort((a, b) => b.score - a.score)
-					.slice(0, limit);
-
-				return createResponse({
-					info: INFO,
-					date: formattedDate,
-					exchange: stockExchange.toUpperCase(),
-					currency: EXCHANGE_INFO[stockExchange as StockExchange].currency,
-					query,
-					matches,
-				});
 			} catch (error) {
 				return createErrorResponse(error);
 			}
@@ -482,65 +107,18 @@ export function registerFinmapTools(server: McpServer) {
 	);
 
 	server.registerTool(
-		"get_market_overview",
+		"analyze_market_overview",
 		{
-			title: "Market overview",
+			title: "Analyze market overview",
 			description:
-				"Get total market cap, volume, value, and performance for an exchange on a specific date with a sector breakdown.",
-			inputSchema: { stockExchange: exchangeSchema, ...dateSchema },
+				"Return aggregated statistics for a stock exchange on a specific date, including total market capitalization, trading volume, total traded value, number of trades, and sector-level market breakdown.",
+			inputSchema: marketOverviewSchema.shape,
 		},
-		async ({
-			stockExchange,
-			year,
-			month,
-			day,
-		}: {
-			stockExchange: StockExchange;
-			year?: number;
-			month?: number;
-			day?: number;
-		}) => {
+		async (input) => {
 			try {
-				const formattedDate = getDate(year, month, day);
-				const marketDataResponse = await fetchMarketData(
-					stockExchange,
-					formattedDate,
+				return createResponse(
+					await getMarketOverview(marketOverviewSchema.parse(input)),
 				);
-
-				const sectorItems = marketDataResponse.securities.data.filter(
-					(item: any) => item[INDICES.TYPE] === "sector",
-				);
-
-				let marketTotal = {};
-				const sectors: any[] = [];
-
-				sectorItems.forEach((item: any) => {
-					const sectorData = {
-						name: item[INDICES.TICKER],
-						marketCap: item[INDICES.MARKET_CAP],
-						marketCapChangePct: item[INDICES.PRICE_CHANGE_PCT],
-						volume: item[INDICES.VOLUME],
-						value: item[INDICES.VALUE],
-						numTrades: item[INDICES.NUM_TRADES],
-						itemsPerSector: item[INDICES.ITEMS_PER_SECTOR],
-					};
-
-					if (item[INDICES.SECTOR] === "") {
-						marketTotal = sectorData;
-					} else {
-						sectors.push(sectorData);
-					}
-				});
-
-				return createResponse({
-					info: INFO,
-					charts: createCharts(stockExchange, formattedDate),
-					date: formattedDate,
-					exchange: stockExchange.toUpperCase(),
-					currency: EXCHANGE_INFO[stockExchange as StockExchange].currency,
-					marketTotal,
-					sectors,
-				});
 			} catch (error) {
 				return createErrorResponse(error);
 			}
@@ -548,64 +126,18 @@ export function registerFinmapTools(server: McpServer) {
 	);
 
 	server.registerTool(
-		"get_sectors_overview",
+		"analyze_sector_performance",
 		{
-			title: "Sector performance",
+			title: "Analyze sector performance",
 			description:
-				"Get aggregated performance metrics by sector for an exchange on a specific date.",
-			inputSchema: {
-				stockExchange: exchangeSchema,
-				...dateSchema,
-				sector: z
-					.string()
-					.optional()
-					.describe("Get data for specific sector only"),
-			},
+				"Return aggregated metrics for each sector in a stock exchange, including sector market capitalization, price change percentage, trading volume, traded value, number of trades, and number of companies in the sector. Optionally filter for a single sector.",
+			inputSchema: sectorsOverviewSchema.shape,
 		},
-		async ({
-			stockExchange,
-			year,
-			month,
-			day,
-			sector,
-		}: {
-			stockExchange: StockExchange;
-			year?: number;
-			month?: number;
-			day?: number;
-			sector?: string;
-		}) => {
+		async (input) => {
 			try {
-				const formattedDate = getDate(year, month, day);
-				const marketDataResponse = await fetchMarketData(
-					stockExchange,
-					formattedDate,
+				return createResponse(
+					await getSectorsOverview(sectorsOverviewSchema.parse(input)),
 				);
-
-				const sectors = marketDataResponse.securities.data
-					.filter(
-						(item: any) =>
-							item[INDICES.TYPE] === "sector" && item[INDICES.SECTOR] !== "",
-					)
-					.filter((item: any) => !sector || item[INDICES.TICKER] === sector)
-					.map((item: any) => ({
-						name: item[INDICES.TICKER],
-						marketCap: item[INDICES.MARKET_CAP],
-						marketCapChangePct: item[INDICES.PRICE_CHANGE_PCT],
-						volume: item[INDICES.VOLUME],
-						value: item[INDICES.VALUE],
-						numTrades: item[INDICES.NUM_TRADES],
-						itemsPerSector: item[INDICES.ITEMS_PER_SECTOR],
-					}));
-
-				return createResponse({
-					info: INFO,
-					charts: createCharts(stockExchange, formattedDate),
-					date: formattedDate,
-					exchange: stockExchange.toUpperCase(),
-					currency: EXCHANGE_INFO[stockExchange as StockExchange].currency,
-					sectors,
-				});
 			} catch (error) {
 				return createErrorResponse(error);
 			}
@@ -613,68 +145,16 @@ export function registerFinmapTools(server: McpServer) {
 	);
 
 	server.registerTool(
-		"get_stock_data",
+		"get_stock_snapshot",
 		{
-			title: "Stock data by ticker",
+			title: "Get stock market snapshot",
 			description:
-				"Get detailed market data for a specific ticker on an exchange and date, including price, change, volume, value, market cap, and trades.",
-			inputSchema: {
-				stockExchange: exchangeSchema,
-				...dateSchema,
-				ticker: z.string().describe("Stock ticker symbol (case-sensitive)"),
-			},
+				"Return detailed trading metrics for a single stock ticker on a specific exchange and trading date, including price open, last sale price, price change percentage, trading volume, traded value, number of trades, and market capitalization.",
+			inputSchema: stockDataSchema.shape,
 		},
-		async ({
-			stockExchange,
-			year,
-			month,
-			day,
-			ticker,
-		}: {
-			stockExchange: StockExchange;
-			year?: number;
-			month?: number;
-			day?: number;
-			ticker: string;
-		}) => {
+		async (input) => {
 			try {
-				const formattedDate = getDate(year, month, day);
-				const marketDataResponse = await fetchMarketData(
-					stockExchange,
-					formattedDate,
-				);
-
-				const stockData = marketDataResponse.securities.data.find(
-					(item: any[]) =>
-						item[INDICES.TYPE] !== "sector" && item[INDICES.TICKER] === ticker,
-				);
-
-				if (!stockData) {
-					throw new Error(
-						`Ticker ${ticker} not found on ${stockExchange} for date ${formattedDate}`,
-					);
-				}
-
-				return createResponse({
-					info: INFO,
-					charts: createCharts(stockExchange, formattedDate),
-					exchange: stockData[INDICES.EXCHANGE],
-					country: stockData[INDICES.COUNTRY],
-					currency: EXCHANGE_INFO[stockExchange as StockExchange].currency,
-					sector: stockData[INDICES.SECTOR],
-					ticker: stockData[INDICES.TICKER],
-					nameEng: stockData[INDICES.NAME_ENG],
-					nameOriginal: stockData[INDICES.NAME_ORIGINAL],
-					priceOpen: stockData[INDICES.PRICE_OPEN],
-					priceLastSale: stockData[INDICES.PRICE_LAST_SALE],
-					priceChangePct: stockData[INDICES.PRICE_CHANGE_PCT],
-					volume: stockData[INDICES.VOLUME],
-					value: stockData[INDICES.VALUE],
-					numTrades: stockData[INDICES.NUM_TRADES],
-					marketCap: stockData[INDICES.MARKET_CAP],
-					listedFrom: stockData[INDICES.LISTED_FROM],
-					listedTill: stockData[INDICES.LISTED_TILL],
-				});
+				return createResponse(await getStockData(stockDataSchema.parse(input)));
 			} catch (error) {
 				return createErrorResponse(error);
 			}
@@ -682,95 +162,16 @@ export function registerFinmapTools(server: McpServer) {
 	);
 
 	server.registerTool(
-		"rank_stocks",
+		"rank_exchange_companies",
 		{
-			title: "Rank stocks",
+			title: "Rank companies by market metric",
 			description:
-				"Rank stocks on an exchange by a chosen metric (marketCap, priceChangePct, volume, value, numTrades) for a specific date with order and limit.",
-			inputSchema: {
-				stockExchange: exchangeSchema,
-				...dateSchema,
-				sortBy: z
-					.enum(SORT_FIELDS)
-					.describe(
-						"Sort by: marketCap, priceChangePct, volume, value, numTrades",
-					),
-				order: z
-					.enum(SORT_ORDERS)
-					.default("desc")
-					.describe("Sort order: asc or desc"),
-				limit: z
-					.number()
-					.int()
-					.min(1)
-					.max(500)
-					.default(10)
-					.describe("Number of results"),
-				sector: z.string().optional().describe("Filter by specific sector"),
-			},
+				"Return companies ranked by a selected market metric on a specific exchange and date. Supported metrics: market capitalization, price change percentage, trading volume, traded value, and number of trades. Results can be limited and optionally filtered by sector.",
+			inputSchema: rankStocksSchema.shape,
 		},
-		async ({
-			stockExchange,
-			year,
-			month,
-			day,
-			sortBy,
-			order,
-			limit,
-			sector,
-		}: {
-			stockExchange: StockExchange;
-			year?: number;
-			month?: number;
-			day?: number;
-			sortBy: SortField;
-			order?: SortOrder;
-			limit?: number;
-			sector?: string;
-		}) => {
+		async (input) => {
 			try {
-				const formattedDate = getDate(year, month, day);
-				const marketDataResponse = await fetchMarketData(
-					stockExchange,
-					formattedDate,
-				);
-
-				const stocks = marketDataResponse.securities.data
-					.filter(
-						(item: any[]) =>
-							item[INDICES.TYPE] !== "sector" && item[INDICES.SECTOR] !== "",
-					)
-					.filter((item: any[]) => !sector || item[INDICES.SECTOR] === sector)
-					.map((item: any[]) => ({
-						ticker: item[INDICES.TICKER],
-						name: item[INDICES.NAME_ENG],
-						sector: item[INDICES.SECTOR],
-						priceLastSale: item[INDICES.PRICE_LAST_SALE],
-						priceChangePct: item[INDICES.PRICE_CHANGE_PCT],
-						marketCap: item[INDICES.MARKET_CAP],
-						volume: item[INDICES.VOLUME],
-						value: item[INDICES.VALUE],
-						numTrades: item[INDICES.NUM_TRADES],
-					}))
-					.sort((a: any, b: any) => {
-						const aVal = a[sortBy],
-							bVal = b[sortBy];
-						return order === "desc" ? bVal - aVal : aVal - bVal;
-					})
-					.slice(0, limit);
-
-				return createResponse({
-					info: INFO,
-					charts: createCharts(stockExchange, formattedDate),
-					date: formattedDate,
-					exchange: stockExchange.toUpperCase(),
-					currency: EXCHANGE_INFO[stockExchange as StockExchange].currency,
-					sortBy,
-					order,
-					limit,
-					count: stocks.length,
-					stocks,
-				});
+				return createResponse(await rankStocks(rankStocksSchema.parse(input)));
 			} catch (error) {
 				return createErrorResponse(error);
 			}
@@ -778,26 +179,18 @@ export function registerFinmapTools(server: McpServer) {
 	);
 
 	server.registerTool(
-		"get_company_profile",
+		"get_company_profile_us",
 		{
-			title: "Company profile (US)",
+			title: "Get US company profile",
 			description:
-				"Get business description, industry, and background for a US-listed company by ticker.",
-			inputSchema: {
-				exchange: z
-					.enum(US_EXCHANGES)
-					.describe("US exchange: amex, nasdaq, nyse"),
-				ticker: z.string().describe("Stock ticker symbol (case-sensitive)"),
-			},
+				"Return business description and background information for a US-listed company by ticker. Supported exchanges: NASDAQ, NYSE, and AMEX.",
+			inputSchema: companyProfileSchema.shape,
 		},
-		async ({ exchange, ticker }: { exchange: USExchange; ticker: string }) => {
+		async (input) => {
 			try {
-				const securityInfo = await fetchSecurityInfo(exchange, ticker);
-				return createResponse({
-					info: INFO,
-					charts: createCharts(exchange),
-					...securityInfo,
-				});
+				return createResponse(
+					await getCompanyProfile(companyProfileSchema.parse(input)),
+				);
 			} catch (error) {
 				return createErrorResponse(error);
 			}

--- a/src/domain/constants.ts
+++ b/src/domain/constants.ts
@@ -1,0 +1,142 @@
+export const BASE_URL = "https://finmap.org";
+export const DATA_BASE_URL = "https://raw.githubusercontent.com/finmap-org";
+
+export const INFO = {
+	provider: "finmap.org",
+	description:
+		"Discover interactive stock charts and curated news at finmap.org",
+	github: "https://github.com/finmap-org",
+	donate: {
+		patreon: "https://patreon.com/finmap",
+		boosty: "https://boosty.to/finmap",
+	},
+	issues: "https://github.com/finmap-org/mcp-server/issues",
+	feedback: "contact@finmap.org",
+};
+
+export const STOCK_EXCHANGES = [
+	"amex",
+	"nasdaq",
+	"nyse",
+	"us-all",
+	"lse",
+	"moex",
+	"bist",
+	"hkex",
+] as const;
+
+export const US_EXCHANGES = ["amex", "nasdaq", "nyse"] as const;
+
+export const SORT_FIELDS = [
+	"priceChangePct",
+	"marketCap",
+	"value",
+	"volume",
+	"numTrades",
+] as const;
+
+export const SORT_ORDERS = ["asc", "desc"] as const;
+
+export type StockExchange = (typeof STOCK_EXCHANGES)[number];
+export type USExchange = (typeof US_EXCHANGES)[number];
+export type SortField = (typeof SORT_FIELDS)[number];
+
+export const INDICES = {
+	EXCHANGE: 0,
+	COUNTRY: 1,
+	TYPE: 2,
+	SECTOR: 3,
+	TICKER: 6,
+	NAME_ENG: 7,
+	NAME_ORIGINAL: 9,
+	NAME_ORIGINAL_SHORT: 10,
+	PRICE_OPEN: 11,
+	PRICE_LAST_SALE: 12,
+	PRICE_CHANGE_PCT: 13,
+	VOLUME: 14,
+	VALUE: 15,
+	NUM_TRADES: 16,
+	MARKET_CAP: 17,
+	LISTED_FROM: 18,
+	LISTED_TILL: 19,
+	ITEMS_PER_SECTOR: 22,
+} as const;
+
+export const EXCHANGE_TO_COUNTRY_MAP: Record<StockExchange, string> = {
+	amex: "us",
+	nasdaq: "us",
+	nyse: "us",
+	"us-all": "us",
+	lse: "uk",
+	moex: "russia",
+	bist: "turkey",
+	hkex: "hongkong",
+};
+
+export const EXCHANGE_INFO: Record<
+	StockExchange,
+	{
+		name: string;
+		country: string;
+		currency: string;
+		availableSince: string;
+		updateFrequency: string;
+	}
+> = {
+	amex: {
+		name: "American Stock Exchange",
+		country: "United States",
+		currency: "USD",
+		availableSince: "2024-12-09",
+		updateFrequency: "Daily",
+	},
+	nasdaq: {
+		name: "NASDAQ Stock Market",
+		country: "United States",
+		currency: "USD",
+		availableSince: "2024-12-09",
+		updateFrequency: "Daily",
+	},
+	nyse: {
+		name: "New York Stock Exchange",
+		country: "United States",
+		currency: "USD",
+		availableSince: "2024-12-09",
+		updateFrequency: "Daily",
+	},
+	"us-all": {
+		name: "US Combined (AMEX + NASDAQ + NYSE)",
+		country: "United States",
+		currency: "USD",
+		availableSince: "2024-12-09",
+		updateFrequency: "Daily",
+	},
+	lse: {
+		name: "London Stock Exchange",
+		country: "United Kingdom",
+		currency: "GBP",
+		availableSince: "2025-02-07",
+		updateFrequency: "Hourly (weekdays)",
+	},
+	moex: {
+		name: "Moscow Exchange",
+		country: "Russia",
+		currency: "RUB",
+		availableSince: "2011-12-19",
+		updateFrequency: "Every 15 minutes (weekdays)",
+	},
+	bist: {
+		name: "Borsa Istanbul",
+		country: "Turkey",
+		currency: "TRY",
+		availableSince: "2015-11-30",
+		updateFrequency: "Every two months",
+	},
+	hkex: {
+		name: "Hong Kong Stock Exchange",
+		country: "Hong Kong",
+		currency: "HKD",
+		availableSince: "2025-09-29",
+		updateFrequency: "Every 30 minutes (weekdays)",
+	},
+};

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import {
+	SORT_FIELDS,
+	SORT_ORDERS,
+	STOCK_EXCHANGES,
+	US_EXCHANGES,
+} from "./constants.js";
+
+const exchangeSchema = z.enum(STOCK_EXCHANGES);
+
+const dateSchema = {
+	year: z.number().int().min(2012).optional(),
+	month: z.number().int().min(1).max(12).optional(),
+	day: z.number().int().min(1).max(31).optional(),
+};
+
+export const listSectorsSchema = z.object({
+	stockExchange: exchangeSchema,
+	...dateSchema,
+});
+
+export const listTickersSchema = z.object({
+	stockExchange: exchangeSchema,
+	...dateSchema,
+	sector: z.string().optional(),
+	englishNames: z.boolean().default(true),
+});
+
+export const searchCompaniesSchema = z.object({
+	stockExchange: exchangeSchema,
+	...dateSchema,
+	query: z.string().min(1),
+	limit: z.number().int().min(1).max(50).default(10),
+});
+
+export const marketOverviewSchema = z.object({
+	stockExchange: exchangeSchema,
+	...dateSchema,
+});
+
+export const sectorsOverviewSchema = z.object({
+	stockExchange: exchangeSchema,
+	...dateSchema,
+	sector: z.string().optional(),
+});
+
+export const rankStocksSchema = z.object({
+	stockExchange: exchangeSchema,
+	...dateSchema,
+	sortBy: z.enum(SORT_FIELDS),
+	order: z.enum(SORT_ORDERS).default("desc"),
+	limit: z.number().int().min(1).max(100).default(10),
+	sector: z.string().optional(),
+});
+
+export const stockDataSchema = z.object({
+	stockExchange: exchangeSchema,
+	...dateSchema,
+	ticker: z.string().min(1),
+});
+
+export const companyProfileSchema = z.object({
+	exchange: z.enum(US_EXCHANGES),
+	ticker: z.string().min(1),
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,26 @@
 import { registerFinmapTools } from "./core.js";
 import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+	companyProfileSchema,
+	getApiOpenApiSpec,
+	getCompanyProfile,
+	getMarketOverview,
+	getSectorsOverview,
+	getStockData,
+	listExchanges,
+	listSectors,
+	listTickers,
+	marketOverviewSchema,
+	rankStocks,
+	rankStocksSchema,
+	searchCompanies,
+	searchCompaniesSchema,
+	sectorsOverviewSchema,
+	stockDataSchema,
+	listSectorsSchema,
+	listTickersSchema,
+} from "./api.js";
 
 export class FinmapMcpServer extends McpAgent {
 	server = new McpServer({
@@ -13,7 +33,7 @@ export class FinmapMcpServer extends McpAgent {
 	}
 }
 
-type Env = {};
+type Env = object;
 
 const serverPromise = FinmapMcpServer.serve("/");
 
@@ -35,6 +55,81 @@ export default {
 			});
 		}
 
+		if (url.pathname === "/api/openapi.json") {
+			return Response.json(getApiOpenApiSpec(url.origin), {
+				headers: { "Access-Control-Allow-Origin": "*" },
+			});
+		}
+
+		if (url.pathname.startsWith("/api/")) {
+			const method = request.method.toUpperCase();
+			const parseBody = async () => request.json().catch(() => ({}));
+			try {
+				if (url.pathname === "/api/list-exchanges" && method === "GET") {
+					return Response.json(listExchanges(), {
+						headers: { "Access-Control-Allow-Origin": "*" },
+					});
+				}
+				if (url.pathname === "/api/list-sectors" && method === "POST") {
+					const input = listSectorsSchema.parse(await parseBody());
+					return Response.json(await listSectors(input), {
+						headers: { "Access-Control-Allow-Origin": "*" },
+					});
+				}
+				if (url.pathname === "/api/list-sector-companies" && method === "POST") {
+					const input = listTickersSchema.parse(await parseBody());
+					return Response.json(await listTickers(input), {
+						headers: { "Access-Control-Allow-Origin": "*" },
+					});
+				}
+				if (url.pathname === "/api/search-companies" && method === "POST") {
+					const input = searchCompaniesSchema.parse(await parseBody());
+					return Response.json(await searchCompanies(input), {
+						headers: { "Access-Control-Allow-Origin": "*" },
+					});
+				}
+				if (url.pathname === "/api/market-overview" && method === "POST") {
+					const input = marketOverviewSchema.parse(await parseBody());
+					return Response.json(await getMarketOverview(input), {
+						headers: { "Access-Control-Allow-Origin": "*" },
+					});
+				}
+				if (url.pathname === "/api/sector-performance" && method === "POST") {
+					const input = sectorsOverviewSchema.parse(await parseBody());
+					return Response.json(await getSectorsOverview(input), {
+						headers: { "Access-Control-Allow-Origin": "*" },
+					});
+				}
+				if (url.pathname === "/api/rank-stocks" && method === "POST") {
+					const input = rankStocksSchema.parse(await parseBody());
+					return Response.json(await rankStocks(input), {
+						headers: { "Access-Control-Allow-Origin": "*" },
+					});
+				}
+				if (url.pathname === "/api/stock-snapshot" && method === "POST") {
+					const input = stockDataSchema.parse(await parseBody());
+					return Response.json(await getStockData(input), {
+						headers: { "Access-Control-Allow-Origin": "*" },
+					});
+				}
+				if (url.pathname === "/api/company-profile" && method === "POST") {
+					const input = companyProfileSchema.parse(await parseBody());
+					return Response.json(await getCompanyProfile(input), {
+						headers: { "Access-Control-Allow-Origin": "*" },
+					});
+				}
+				return Response.json(
+					{ error: "Not found" },
+					{ status: 404, headers: { "Access-Control-Allow-Origin": "*" } },
+				);
+			} catch (error) {
+				return Response.json(
+					{ error: error instanceof Error ? error.message : String(error) },
+					{ status: 400, headers: { "Access-Control-Allow-Origin": "*" } },
+				);
+			}
+		}
+
 		if (url.pathname === "/") {
 			// Handle GET requests for SSE stream
 			if (request.method === "GET") {
@@ -51,7 +146,7 @@ export default {
 							const handleAbort = () => {
 								try {
 									writer.close();
-								} catch (e) {
+								} catch (_e) {
 									// Ignore errors from closing the stream
 								}
 							};
@@ -62,7 +157,7 @@ export default {
 								await new Promise((resolve) => setTimeout(resolve, 20000));
 								try {
 									await writer.write(encoder.encode(":\n\n")); // Keep-alive ping
-								} catch (e) {
+								} catch (_e) {
 									break; // Client disconnected
 								}
 							}

--- a/src/infra/github-client.ts
+++ b/src/infra/github-client.ts
@@ -1,0 +1,46 @@
+import {
+	DATA_BASE_URL,
+	EXCHANGE_INFO,
+	EXCHANGE_TO_COUNTRY_MAP,
+	type StockExchange,
+	type USExchange,
+} from "../domain/constants.js";
+
+export type MarketDataResponse = {
+	securities: {
+		data: unknown[][];
+	};
+};
+
+export async function fetchMarketData(stockExchange: StockExchange, formattedDate: string) {
+	const country = EXCHANGE_TO_COUNTRY_MAP[stockExchange];
+	const date = formattedDate.replaceAll("-", "/");
+	const url = `${DATA_BASE_URL}/data-${country}/refs/heads/main/marketdata/${date}/${stockExchange}.json`;
+	const response = await fetch(url, {
+		cf: { cacheTtl: 300, cacheEverything: true },
+	} as unknown as RequestInit);
+	if (response.status === 404) {
+		throw new Error(
+			`Not found, try another date. The date must be on or after ${EXCHANGE_INFO[stockExchange].availableSince} for ${stockExchange}`,
+		);
+	}
+	if (!response.ok) {
+		throw new Error(`Upstream fetch failed (${response.status})`);
+	}
+	return (await response.json()) as MarketDataResponse;
+}
+
+export async function fetchSecurityInfo(exchange: USExchange, ticker: string) {
+	const firstLetter = ticker.charAt(0).toUpperCase();
+	const url = `${DATA_BASE_URL}/data-us/refs/heads/main/securities/${exchange}/${firstLetter}/${ticker}.json`;
+	const response = await fetch(url, {
+		cf: { cacheTtl: 1800, cacheEverything: true },
+	} as unknown as RequestInit);
+	if (response.status === 404) {
+		throw new Error(`Security ${ticker} not found on ${exchange}`);
+	}
+	if (!response.ok) {
+		throw new Error(`Upstream fetch failed (${response.status})`);
+	}
+	return response.json();
+}


### PR DESCRIPTION
### Motivation
- Modularize and simplify the MCP server by extracting Finmap logic into a dedicated API layer and domain modules for clearer separation of concerns.
- Expose a compact HTTP API for GPT Actions and direct integrations with an OpenAPI/GPT Actions schema to support automated tooling and third-party clients.
- Improve maintainability by centralizing constants, schemas and upstream fetching code, and by updating tooling configuration.

### Description
- Extracted core Finmap logic into a new API module `src/api.ts` providing functions such as `listExchanges`, `listSectors`, `listTickers`, `searchCompanies`, `getMarketOverview`, `getSectorsOverview`, `rankStocks`, `getStockData`, and `getCompanyProfile` and a helper `getApiOpenApiSpec` for the runtime OpenAPI spec.
- Added domain files `src/domain/constants.ts` and `src/domain/schemas.ts` to centralize exchange/constants metadata and `zod` input schemas, and added `src/infra/github-client.ts` to encapsulate upstream GitHub fetches with caching and error handling.
- Refactored `src/core.ts` to call the new API functions and switched tool IDs/titles to clearer names (for example `list_exchanges` -> `list_supported_exchanges`, `get_stock_data` -> `get_stock_snapshot`) while wiring `zod` schemas as tool input validation.
- Implemented an HTTP API surface in `src/index.ts` that serves `GET /api/openapi.json` and REST endpoints under `/api/*` that validate requests with the new schemas and return JSON with CORS headers.
- Added `gpt-actions.yaml` as a ready-to-import GPT Actions (OpenAPI) schema describing the wrapper endpoints and operations.
- Updated `README.md` to advertise the HTTP API and the `gpt-actions.yaml` schema, and fixed the `hkex` earliest data date; upgraded `biome.json` configuration for tooling/formatting changes.

### Testing
- No automated tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69addc93ff4c83298410043c5299fc96)