### PR TITLE
Centralize CORS handling and bump dependencies (agents, biome, wrangler, workerd, etc.)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,32 +16,33 @@
 			],
 			"license": "LGPL-3.0-or-later",
 			"dependencies": {
-				"agents": "^0.7.6",
+				"agents": "^0.8.1",
 				"zod": "^4.3.6"
 			},
 			"bin": {
 				"finmap-mcp": "dist/stdio-server.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.7",
+				"@biomejs/biome": "^2.4.8",
 				"@types/node": "^25.5.0",
 				"rimraf": "^6.1.3",
 				"tsx": "^4.21.0",
 				"typescript": "5.9.3",
-				"wrangler": "^4.74.0"
+				"wrangler": "^4.77.0"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@ai-sdk/gateway": {
-			"version": "3.0.66",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.66.tgz",
-			"integrity": "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==",
+			"version": "3.0.79",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.79.tgz",
+			"integrity": "sha512-Wk2QJpqd0em5YcR49uoMCy9msyANAYgjXdlRcqqRt2fz4rNLnMMrKOlLwAXoFzR1ElR3bj4e/k6hscRfjpzSGA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@ai-sdk/provider": "3.0.8",
-				"@ai-sdk/provider-utils": "4.0.19",
+				"@ai-sdk/provider-utils": "4.0.21",
 				"@vercel/oidc": "3.1.0"
 			},
 			"engines": {
@@ -56,6 +57,7 @@
 			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
 			"integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"json-schema": "^0.4.0"
 			},
@@ -64,10 +66,11 @@
 			}
 		},
 		"node_modules/@ai-sdk/provider-utils": {
-			"version": "4.0.19",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz",
-			"integrity": "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==",
+			"version": "4.0.21",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.21.tgz",
+			"integrity": "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@ai-sdk/provider": "3.0.8",
 				"@standard-schema/spec": "^1.1.0",
@@ -119,9 +122,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.7.tgz",
-			"integrity": "sha512-vXrgcmNGZ4lpdwZSpMf1hWw1aWS6B+SyeSYKTLrNsiUsAdSRN0J4d/7mF3ogJFbIwFFSOL3wT92Zzxia/d5/ng==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.8.tgz",
+			"integrity": "sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -135,20 +138,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.7",
-				"@biomejs/cli-darwin-x64": "2.4.7",
-				"@biomejs/cli-linux-arm64": "2.4.7",
-				"@biomejs/cli-linux-arm64-musl": "2.4.7",
-				"@biomejs/cli-linux-x64": "2.4.7",
-				"@biomejs/cli-linux-x64-musl": "2.4.7",
-				"@biomejs/cli-win32-arm64": "2.4.7",
-				"@biomejs/cli-win32-x64": "2.4.7"
+				"@biomejs/cli-darwin-arm64": "2.4.8",
+				"@biomejs/cli-darwin-x64": "2.4.8",
+				"@biomejs/cli-linux-arm64": "2.4.8",
+				"@biomejs/cli-linux-arm64-musl": "2.4.8",
+				"@biomejs/cli-linux-x64": "2.4.8",
+				"@biomejs/cli-linux-x64-musl": "2.4.8",
+				"@biomejs/cli-win32-arm64": "2.4.8",
+				"@biomejs/cli-win32-x64": "2.4.8"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.7.tgz",
-			"integrity": "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.8.tgz",
+			"integrity": "sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -163,9 +166,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.7.tgz",
-			"integrity": "sha512-I+cOG3sd/7HdFtvDSnF9QQPrWguUH7zrkIMMykM3PtfWU9soTcS2yRb9Myq6MHmzbeCT08D1UmY+BaiMl5CcoQ==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.8.tgz",
+			"integrity": "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==",
 			"cpu": [
 				"x64"
 			],
@@ -180,9 +183,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.7.tgz",
-			"integrity": "sha512-om6FugwmibzfP/6ALj5WRDVSND4H2G9X0nkI1HZpp2ySf9lW2j0X68oQSaHEnls6666oy4KDsc5RFjT4m0kV0w==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.8.tgz",
+			"integrity": "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==",
 			"cpu": [
 				"arm64"
 			],
@@ -197,9 +200,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.7.tgz",
-			"integrity": "sha512-I2NvM9KPb09jWml93O2/5WMfNR7Lee5Latag1JThDRMURVhPX74p9UDnyTw3Ae6cE1DgXfw7sqQgX7rkvpc0vw==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.8.tgz",
+			"integrity": "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==",
 			"cpu": [
 				"arm64"
 			],
@@ -214,9 +217,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.7.tgz",
-			"integrity": "sha512-bV8/uo2Tj+gumnk4sUdkerWyCPRabaZdv88IpbmDWARQQoA/Q0YaqPz1a+LSEDIL7OfrnPi9Hq1Llz4ZIGyIQQ==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.8.tgz",
+			"integrity": "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==",
 			"cpu": [
 				"x64"
 			],
@@ -231,9 +234,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.7.tgz",
-			"integrity": "sha512-00kx4YrBMU8374zd2wHuRV5wseh0rom5HqRND+vDldJPrWwQw+mzd/d8byI9hPx926CG+vWzq6AeiT7Yi5y59g==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.8.tgz",
+			"integrity": "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==",
 			"cpu": [
 				"x64"
 			],
@@ -248,9 +251,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.7.tgz",
-			"integrity": "sha512-hOUHBMlFCvDhu3WCq6vaBoG0dp0LkWxSEnEEsxxXvOa9TfT6ZBnbh72A/xBM7CBYB7WgwqboetzFEVDnMxelyw==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.8.tgz",
+			"integrity": "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -265,9 +268,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.7.tgz",
-			"integrity": "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ==",
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.8.tgz",
+			"integrity": "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==",
 			"cpu": [
 				"x64"
 			],
@@ -285,8 +288,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
 			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
 			"version": "0.4.2",
@@ -299,9 +301,9 @@
 			}
 		},
 		"node_modules/@cloudflare/unenv-preset": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
-			"integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
+			"integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"peerDependencies": {
@@ -315,9 +317,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260312.1.tgz",
-			"integrity": "sha512-HUAtDWaqUduS6yasV6+NgsK7qBpP1qGU49ow/Wb117IHjYp+PZPUGReDYocpB4GOMRoQlvdd4L487iFxzdARpw==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260317.1.tgz",
+			"integrity": "sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==",
 			"cpu": [
 				"x64"
 			],
@@ -332,9 +334,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260312.1.tgz",
-			"integrity": "sha512-DOn7TPTHSxJYfi4m4NYga/j32wOTqvJf/pY4Txz5SDKWIZHSTXFyGz2K4B+thoPWLop/KZxGoyTv7db0mk/qyw==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260317.1.tgz",
+			"integrity": "sha512-M/MnNyvO5HMgoIdr3QHjdCj2T1ki9gt0vIUnxYxBu9ISXS/jgtMl6chUVPJ7zHYBn9MyYr8ByeN6frjYxj0MGg==",
 			"cpu": [
 				"arm64"
 			],
@@ -349,9 +351,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260312.1.tgz",
-			"integrity": "sha512-TdkIh3WzPXYHuvz7phAtFEEvAxvFd30tHrm4gsgpw0R0F5b8PtoM3hfL2uY7EcBBWVYUBtkY2ahDYFfufnXw/g==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260317.1.tgz",
+			"integrity": "sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==",
 			"cpu": [
 				"x64"
 			],
@@ -366,9 +368,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260312.1.tgz",
-			"integrity": "sha512-kNauZhL569Iy94t844OMwa1zP6zKFiL3xiJ4tGLS+TFTEfZ3pZsRH6lWWOtkXkjTyCmBEOog0HSEKjIV4oAffw==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260317.1.tgz",
+			"integrity": "sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==",
 			"cpu": [
 				"arm64"
 			],
@@ -383,9 +385,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260312.1.tgz",
-			"integrity": "sha512-5dBrlSK+nMsZy5bYQpj8t9iiQNvCRlkm9GGvswJa9vVU/1BNO4BhJMlqOLWT24EmFyApZ+kaBiPJMV8847NDTg==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260317.1.tgz",
+			"integrity": "sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==",
 			"cpu": [
 				"x64"
 			],
@@ -420,9 +422,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-			"integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+			"integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1453,6 +1455,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -1500,9 +1503,9 @@
 			}
 		},
 		"node_modules/@speed-highlight/core": {
-			"version": "1.2.14",
-			"resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
-			"integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
+			"version": "1.2.15",
+			"resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+			"integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -1510,7 +1513,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -1539,6 +1543,7 @@
 			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
 			"integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">= 20"
 			}
@@ -1557,9 +1562,9 @@
 			}
 		},
 		"node_modules/agents": {
-			"version": "0.7.6",
-			"resolved": "https://registry.npmjs.org/agents/-/agents-0.7.6.tgz",
-			"integrity": "sha512-wR5L+3t+kIN1aog7AqAs5RBKfW4GhYtdSEE2thNvWefaZXrEZXDzN8NVaO2CMVEwNWAG+edqEfxzMOViMOlUJQ==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/agents/-/agents-0.8.1.tgz",
+			"integrity": "sha512-rOWvZlUmbWEQ/KVIzF39FeHMcbqFYMnxKj7J/drilnf0W8uMK6zq8XudU5XDSV40u7/ZfkqMqbXhCvjR11y2ww==",
 			"license": "MIT",
 			"dependencies": {
 				"@cfworker/json-schema": "^4.1.1",
@@ -1568,10 +1573,10 @@
 				"json-schema": "^0.4.0",
 				"json-schema-to-typescript": "^15.0.4",
 				"mimetext": "^3.0.28",
-				"nanoid": "^5.1.6",
+				"nanoid": "^5.1.7",
 				"partyserver": "^0.3.3",
 				"partysocket": "1.1.16",
-				"picomatch": "^4.0.3",
+				"picomatch": "^4.0.4",
 				"yargs": "^18.0.0"
 			},
 			"bin": {
@@ -1580,15 +1585,14 @@
 			"peerDependencies": {
 				"@ai-sdk/openai": "^3.0.0",
 				"@ai-sdk/react": "^3.0.0",
-				"@cloudflare/ai-chat": "^0.1.8",
-				"@cloudflare/codemode": "^0.1.3",
+				"@cloudflare/ai-chat": "^0.2.2",
+				"@cloudflare/codemode": "^0.3.0",
 				"@x402/core": "^2.0.0",
 				"@x402/evm": "^2.0.0",
 				"ai": "^6.0.0",
-				"just-bash": "^2.11.0",
 				"react": "^19.0.0",
 				"viem": ">=2.0.0",
-				"zod": "^3.25.0 || ^4.0.0"
+				"zod": "^4.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@ai-sdk/openai": {
@@ -1609,24 +1613,21 @@
 				"@x402/evm": {
 					"optional": true
 				},
-				"just-bash": {
-					"optional": true
-				},
 				"viem": {
 					"optional": true
 				}
 			}
 		},
 		"node_modules/ai": {
-			"version": "6.0.116",
-			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
-			"integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
+			"version": "6.0.137",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.137.tgz",
+			"integrity": "sha512-9e/mNMTmXmMkmldEJPIumy9FFBuUWHUyj2yF8EglC3VVOhVVBwlnpeHYSFKdNc13Jj6Hso3EJcZioMaofgCs4A==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@ai-sdk/gateway": "3.0.66",
+				"@ai-sdk/gateway": "3.0.79",
 				"@ai-sdk/provider": "3.0.8",
-				"@ai-sdk/provider-utils": "4.0.19",
+				"@ai-sdk/provider-utils": "4.0.21",
 				"@opentelemetry/api": "1.9.0"
 			},
 			"engines": {
@@ -2105,7 +2106,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
 			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.1",
@@ -2323,9 +2323,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.13.6",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-			"integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+			"version": "4.13.7",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+			"integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2390,11 +2390,10 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.8",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-			"integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+			"version": "4.12.9",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+			"integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -2493,9 +2492,9 @@
 			"license": "ISC"
 		},
 		"node_modules/jose": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
-			"integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+			"integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -2679,16 +2678,16 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260312.1",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260312.1.tgz",
-			"integrity": "sha512-YSWxec9ssisqkQgaCgcIQxZlB41E9hMiq1nxUgxXHRrE9NsfyC6ptSt8yfgBobsKIseAVKLTB/iEDpMumBv8oA==",
+			"version": "4.20260317.2",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.2.tgz",
+			"integrity": "sha512-qNL+yWAFMX6fr0pWU6Lx1vNpPobpnDSF1V8eunIckWvoIQl8y1oBjL2RJFEGY3un+l3f9gwW9dirDPP26usYJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"sharp": "^0.34.5",
 				"undici": "7.24.4",
-				"workerd": "1.20260312.1",
+				"workerd": "1.20260317.1",
 				"ws": "8.18.0",
 				"youch": "4.1.0-beta.10"
 			},
@@ -2898,11 +2897,10 @@
 			"license": "MIT"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3417,7 +3415,6 @@
 			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"pathe": "^2.0.3"
 			}
@@ -3456,13 +3453,12 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20260312.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260312.1.tgz",
-			"integrity": "sha512-nNpPkw9jaqo79B+iBCOiksx+N62xC+ETIfyzofUEdY3cSOHJg6oNnVSHm7vHevzVblfV76c8Gr0cXHEapYMBEg==",
+			"version": "1.20260317.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260317.1.tgz",
+			"integrity": "sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -3470,41 +3466,41 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260312.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260312.1",
-				"@cloudflare/workerd-linux-64": "1.20260312.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260312.1",
-				"@cloudflare/workerd-windows-64": "1.20260312.1"
+				"@cloudflare/workerd-darwin-64": "1.20260317.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260317.1",
+				"@cloudflare/workerd-linux-64": "1.20260317.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260317.1",
+				"@cloudflare/workerd-windows-64": "1.20260317.1"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.74.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.74.0.tgz",
-			"integrity": "sha512-3qprbhgdUyqYGHZ+Y1k0gsyHLMOlLrKL/HU0LDqLlCkbsKPprUA0/ThE4IZsxD84xAAXY6pv5JUuxS2+OnMa3A==",
+			"version": "4.77.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.77.0.tgz",
+			"integrity": "sha512-E2Gm69+K++BFd3QvoWjC290RPQj1vDOUotA++sNHmtKPb7EP6C8Qv+1D5Ii73tfZtyNgakpqHlh8lBBbVWTKAQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.4.2",
-				"@cloudflare/unenv-preset": "2.15.0",
+				"@cloudflare/unenv-preset": "2.16.0",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.27.3",
-				"miniflare": "4.20260312.1",
+				"miniflare": "4.20260317.2",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260312.1"
+				"workerd": "1.20260317.1"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
 				"wrangler2": "bin/wrangler.js"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=20.3.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260312.1"
+				"@cloudflare/workers-types": "^4.20260317.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -4127,7 +4123,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -73,15 +73,15 @@
 		"package": "npm run build:stdio && npm pack --pack-destination dist"
 	},
 	"dependencies": {
-		"agents": "^0.7.6",
+		"agents": "^0.8.1",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.7",
+		"@biomejs/biome": "^2.4.8",
 		"@types/node": "^25.5.0",
 		"rimraf": "^6.1.3",
 		"tsx": "^4.21.0",
 		"typescript": "5.9.3",
-		"wrangler": "^4.74.0"
+		"wrangler": "^4.77.0"
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,21 +35,33 @@ export class FinmapMcpServer extends McpAgent {
 
 type Env = object;
 
-const serverPromise = FinmapMcpServer.serve("/");
+const apiAllowHeaders = "Content-Type, Accept, Authorization";
+const mcpAllowHeaders =
+	"Content-Type, Accept, Authorization, mcp-session-id, mcp-protocol-version, last-event-id";
+const mcpExposeHeaders = "Content-Type, Authorization, mcp-session-id, mcp-protocol-version";
+
+const serverPromise = FinmapMcpServer.serve("/", {
+	corsOptions: {
+		origin: "*",
+		methods: "GET, POST, DELETE, OPTIONS",
+		headers: mcpAllowHeaders,
+		maxAge: 86400,
+		exposeHeaders: mcpExposeHeaders,
+	},
+});
 
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		const url = new URL(request.url);
 
-		// Handle CORS preflight requests
-		if (request.method === "OPTIONS") {
+		// Handle CORS preflight requests for REST API endpoints
+		if (request.method === "OPTIONS" && url.pathname.startsWith("/api/")) {
 			return new Response(null, {
 				status: 200,
 				headers: {
 					"Access-Control-Allow-Origin": "*",
 					"Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-					"Access-Control-Allow-Headers":
-						"Content-Type, Accept, Authorization, mcp-session-id, mcp-protocol-version, Last-Event-ID",
+					"Access-Control-Allow-Headers": apiAllowHeaders,
 					"Access-Control-Max-Age": "86400",
 				},
 			});
@@ -131,94 +143,10 @@ export default {
 		}
 
 		if (url.pathname === "/") {
-			// Handle GET requests for SSE stream
-			if (request.method === "GET") {
-				const acceptHeader = request.headers.get("Accept");
-				if (acceptHeader?.includes("text/event-stream")) {
-					// Create a transform stream to handle SSE events
-					const { readable, writable } = new TransformStream();
-					const writer = writable.getWriter();
-					const encoder = new TextEncoder();
-
-					// Handle server side event stream
-					ctx.waitUntil(
-						(async () => {
-							const handleAbort = () => {
-								try {
-									writer.close();
-								} catch (_e) {
-									// Ignore errors from closing the stream
-								}
-							};
-							request.signal.addEventListener("abort", handleAbort);
-
-							// Keep connection alive and allow server to send events
-							while (!request.signal.aborted) {
-								await new Promise((resolve) => setTimeout(resolve, 20000));
-								try {
-									await writer.write(encoder.encode(":\n\n")); // Keep-alive ping
-								} catch (_e) {
-									break; // Client disconnected
-								}
-							}
-
-							request.signal.removeEventListener("abort", handleAbort);
-						})(),
-					);
-
-					return new Response(readable, {
-						headers: {
-							"Content-Type": "text/event-stream",
-							"Cache-Control": "no-cache",
-							Connection: "keep-alive",
-							"Access-Control-Allow-Origin": "*",
-							"Access-Control-Expose-Headers":
-								"Content-Type, Authorization, Mcp-Session-Id, mcp-protocol-version",
-						},
-					});
-				}
-
-				// If Accept header doesn't include text/event-stream, return 405
-				return new Response(
-					JSON.stringify({
-						jsonrpc: "2.0",
-						error: {
-							code: -32000,
-							message: "Method not allowed",
-						},
-						id: null,
-					}),
-					{
-						status: 405,
-						headers: {
-							"Content-Type": "application/json",
-							"Access-Control-Allow-Origin": "*",
-						},
-					},
-				);
-			}
-
 			const server = await serverPromise;
 			const response = await server.fetch(request, env, ctx);
 
-			// Add CORS headers to response
-			const newHeaders = new Headers(response.headers);
-			newHeaders.set("Access-Control-Allow-Origin", "*");
-			newHeaders.set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-			newHeaders.set(
-				"Access-Control-Allow-Headers",
-				"Content-Type, Accept, Authorization, mcp-session-id, mcp-protocol-version, Last-Event-ID",
-			);
-			newHeaders.set(
-				"Access-Control-Expose-Headers",
-				"Content-Type, Authorization, Mcp-Session-Id, mcp-protocol-version",
-			);
-
-			return new Response(response.body, {
-				status: response.status,
-				statusText: response.statusText,
-				headers: newHeaders,
-			});
+			return response;
 		}
 
 		return new Response("Not found", { status: 404 });


### PR DESCRIPTION
### Motivation

- Add proper CORS behavior for both REST API endpoints and the MCP server and avoid ad-hoc header rewriting.
- Keep dependencies up-to-date to pick up bugfixes and compatibility updates for `agents`, tooling and runtime libs.

### Description

- Configure `FinmapMcpServer.serve` with `corsOptions` and introduce `apiAllowHeaders`, `mcpAllowHeaders`, and `mcpExposeHeaders` constants to centralize CORS rules in `src/index.ts`.
- Restrict manual OPTIONS preflight handling to REST API endpoints under `/api/` and use `apiAllowHeaders` for those responses.
- Remove manual SSE keep-alive / header-rewrite logic for `/` and stop mutating responses from `server.fetch`, deferring CORS behavior to the server configuration.
- Bump dependencies in `package.json` and `package-lock.json`, including `agents` `^0.7.6 -> ^0.8.1`, `@biomejs/biome` `^2.4.7 -> ^2.4.8`, `wrangler` `^4.74.0 -> ^4.77.0`, and many lockfile updates for related packages (`workerd`, `miniflare`, `@ai-sdk/*`, `picomatch`, `jose`, etc.).

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2be5f95cc832986220f4a9784289d)